### PR TITLE
Matches in let-bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,6 +714,8 @@ When evaluating such a tree, the case tree bound to the variable is required to 
 
 Note that unlike the locations of all ordinary case trees, which are checking contexts, the bound term in a let-expression is required to synthesize.  Thus, when using a match expression there, you must either use a synthesizing form of match (that is, one with an explicit motive, or a non-dependent one whose first branch synthesizes) or ascribe it to a type, the latter either in the ordinary way with `let x ≔ match n [ … ] : A in M` or in the let-sugared way with `let x : A ≔ match n [ … ] in M`.  This is the only place where it matters whether a match-expression synthesizes.
 
+Matching in a case-tree let-binding allows you to effectively perform a match anywhere in a term that isn't inside a non-case-tree abstraction, by lifting the match out to the nearest enclosing part of the case tree (so that all the variables it needs are available) and let-binding it to a variable there.  But if you want to perform a match inside a non-case-tree abstraction, then you need to define that abstraction globally as a helper function.
+
 
 ## Codatatypes and comatching
 

--- a/lib/core/act.ml
+++ b/lib/core/act.ml
@@ -86,13 +86,13 @@ let rec act_value : type m n s. s value -> (m, n) deg -> s value =
                 act_value (CubeOf.find tys' fd) fc);
           } in
       Inst { tm = act_uninst tm fa; dim; args; tys }
-  | Lam (x, body) ->
+  | Lam (x, body, energy) ->
       let (Of fa) = deg_plus_to s (dim_binder body) ~on:"lambda" in
-      Lam (act_variables x fa, act_binder body fa)
-  | Struct (fields, ins) ->
+      Lam (act_variables x fa, act_binder body fa, energy)
+  | Struct (fields, ins, energy) ->
       let (Insfact_comp (fa, new_ins, _, _)) = insfact_comp ins s in
-      Struct
-        (Abwd.map (fun (tm, l) -> (lazy (act_evaluation (Lazy.force tm) fa), l)) fields, new_ins)
+      let fields = Abwd.map (fun (tm, l) -> (lazy (act_evaluation (Lazy.force tm) fa), l)) fields in
+      Struct (fields, new_ins, energy)
   | Constr (name, dim, args) ->
       let (Of fa) = deg_plus_to s dim ~on:"constr" in
       Constr (name, dom_deg fa, List.map (fun tm -> act_value_cube tm fa) args)
@@ -100,9 +100,9 @@ let rec act_value : type m n s. s value -> (m, n) deg -> s value =
 and act_evaluation : type m n s. s evaluation -> (m, n) deg -> s evaluation =
  fun tm s ->
   match tm with
-  | Unrealized -> Unrealized
-  | Realize tm -> Realize (act_value tm s)
-  | Val tm -> Val (act_value tm s)
+  | Unrealized e -> Unrealized e
+  | Realize (tm, e) -> Realize (act_value tm s, e)
+  | Val (tm, e) -> Val (act_value tm s, e)
   | Canonical c -> Canonical (act_canonical c s)
 
 and act_alignment : type m n h. h alignment -> (m, n) deg -> h alignment =

--- a/lib/core/command.ml
+++ b/lib/core/command.ml
@@ -58,9 +58,9 @@ let check_term : defined_const -> unit = function
       Global.add const pi_cty (Defined tree)
   | Defined_synth { const; params; tm } ->
       let (Checked_tel (cparams, ctx)) = check_tel Ctx.empty params in
-      let ctm, ety = synth ctx tm in
+      let ctm, ety = synth (Potential (const, Ctx.apps ctx, Ctx.lam ctx)) ctx tm in
       let cty = readback_val ctx ety in
-      Global.add const (Telescope.pis cparams cty) (Defined (Ctx.lam ctx (Realize ctm)))
+      Global.add const (Telescope.pis cparams cty) (Defined (Ctx.lam ctx ctm))
 
 (* When checking a "def", therefore, we first iterate through checking the parameters and types, and then go back and check all the terms.  Moreover, whenever we check a type, we temporarily define the corresponding constant as an axiom having that type, so that its type can be used recursively in typechecking its definition, as well as the types of later mutual constants and the definitions of any other mutual constants. *)
 let check_defs (defs : defconst list) : unit =

--- a/lib/core/ctx.ml
+++ b/lib/core/ctx.ml
@@ -331,9 +331,9 @@ module Ordered = struct
     | Emp -> tree
     | Lock ctx -> lam ctx tree
     | Snoc (ctx, Vis { dim; plusdim; vars; bindings; fplus = Zero; _ }, _) when all_free bindings ->
-        lam ctx (Lam (Variables (dim, plusdim, vars), tree))
+        lam ctx (Lam (Variables (dim, plusdim, vars), Potential, tree))
     | Snoc (ctx, Invis bindings, _) when all_free bindings ->
-        lam ctx (Lam (singleton_variables (CubeOf.dim bindings) None, tree))
+        lam ctx (Lam (singleton_variables (CubeOf.dim bindings) None, Potential, tree))
     | _ -> fatal (Anomaly "let-bound variable in Ctx.lam")
 
   (* Delete some level variables from a context by making their bindings into "unknown".  This will cause readback to raise No_such_level if it encounters one of those variables, which can then be trapped as an occurs-check. *)

--- a/lib/core/dump.ml
+++ b/lib/core/dump.ml
@@ -31,8 +31,8 @@ let rec dvalue : type s. int -> formatter -> s value -> unit =
       else fprintf ppf "Uninst (%a, ?)" uninst tm
   | Inst { tm; dim = d; args = _; tys = _ } ->
       fprintf ppf "Inst (%a, %a, ?, ?)" uninst tm dim (D.pos d)
-  | Lam (_, _) -> fprintf ppf "Lam ?"
-  | Struct (f, _) -> fprintf ppf "Struct (%a)" fields f
+  | Lam (_, _, _) -> fprintf ppf "Lam ?"
+  | Struct (f, _, _) -> fprintf ppf "Struct (%a)" fields f
   | Constr (c, d, args) ->
       fprintf ppf "Constr (%s, %a, %d)" (Constr.to_string c) dim d (List.length args)
 
@@ -51,9 +51,9 @@ and fields :
 and evaluation : type s. formatter -> s evaluation -> unit =
  fun ppf v ->
   match v with
-  | Unrealized -> fprintf ppf "Unrealized"
-  | Realize v -> fprintf ppf "Realize (%a)" value v
-  | Val v -> fprintf ppf "Val (%a)" value v
+  | Unrealized _ -> fprintf ppf "Unrealized"
+  | Realize (v, _) -> fprintf ppf "Realize (%a)" value v
+  | Val (v, _) -> fprintf ppf "Val (%a)" value v
   | Canonical _ -> fprintf ppf "Canonical ?"
 
 and uninst : formatter -> uninst -> unit =
@@ -118,13 +118,13 @@ and term : type b s. formatter -> (b, s) term -> unit =
   | Pi (x, doms, _) ->
       fprintf ppf "Pi^(%a) (%s, ?, ?)" dim (CubeOf.dim doms) (Option.value x ~default:"_")
   | App (fn, arg) -> fprintf ppf "App (%a, (... %a))" term fn term (CubeOf.find_top arg)
-  | Lam (_, body) -> fprintf ppf "Lam (?, %a)" term body
+  | Lam (_, _, body) -> fprintf ppf "Lam (?, %a)" term body
   | Constr (c, _, _) -> fprintf ppf "Constr (%s, ?, ?)" (Constr.to_string c)
   | Act (tm, s) -> fprintf ppf "Act (%a, %s)" term tm (string_of_deg s)
-  | Let (_, _, _) -> fprintf ppf "Let (?,?,?)"
-  | Struct (_, _, _) -> fprintf ppf "Struct (?,?,?)"
+  | Let (_, _, _, _) -> fprintf ppf "Let (?,?,?,?)"
+  | Struct _ -> fprintf ppf "Struct ?"
   | Match _ -> fprintf ppf "Match (?,?,?)"
-  | Realize tm -> fprintf ppf "Realize (%a)" term tm
+  | Realize (tm, _) -> fprintf ppf "Realize (%a)" term tm
   | Canonical c -> fprintf ppf "Canonical (%a)" canonical c
 
 and canonical : type b. formatter -> b canonical -> unit =

--- a/lib/core/energy.ml
+++ b/lib/core/energy.ml
@@ -1,14 +1,20 @@
 open Util
 
-(* At both the checked and the value level we have actually two different types to define: ordinary terms and case trees.  However, there is some overlap in the types of constructors and operations that these support: they can both contain lambda-abstractions and structs.  Thus, to avoid duplication of code, we actually define both together as one GADT type family, indexed by a two-element type to distinguish them.  We name the two groups after the two kinds of energy:
+(* At both the checked and the value level we have actually three different types to define: ordinary terms, case trees, and let/match case trees to appear in let-bindings.  However, there is some overlap in the types of constructors and operations that these support.  Thus, to avoid duplication of code, we actually define all together as one GADT type family, indexed by a three-element type to distinguish them.  We name the two main groups after the two kinds of energy:
 
    - Ordinary terms are "kinetic", because ordinary computation applies directly to them.
    - Case trees are "potential", because they don't compute until enough arguments are applied to reach a leaf of the case tree.  That leaf can be either a kinetic term or information about a canonical type (which is not a computation, just a specification of behavior).
+   - Let/match case trees are "chemical", a special kind of potential energy that's freed by breaking things apart (i.e. decomposing an element of a datatype into constructors, as with a match).
 *)
 
 type kinetic = private Dummy_kinetic
 type potential = private Dummy_potential
-type _ energy = Kinetic : kinetic energy | Potential : potential energy
+type chemical = private Dummy_chemical
+
+type _ energy =
+  | Kinetic : kinetic energy
+  | Potential : potential energy
+  | Chemical : chemical energy
 
 module Energy = struct
   type 'a t = 'a energy
@@ -18,8 +24,19 @@ module Energy = struct
     match (s1, s2) with
     | Kinetic, Kinetic -> Eq
     | Potential, Potential -> Eq
+    | Chemical, Chemical -> Eq
     | _ -> Neq
 end
 
-(* Structs can have or lack eta-conversion, but the only kinetic ones are the ones with eta (records). *)
+(* Structs can have or lack eta-conversion, but the only kinetic or chemical ones are the ones with eta (records). *)
 type _ eta = Eta : 's eta | Noeta : potential eta
+
+(* The term bound by a kinetic let must be kinetic, while that bound by a potential or chemical let must be chemical. *)
+type (_, _) lettable =
+  | Kinetic : (kinetic, kinetic) lettable
+  | Chemical : (chemical, chemical) lettable
+  | Potential : (chemical, potential) lettable
+
+(* Subclassifiers *)
+type _ nonkinetic = Chemical : chemical nonkinetic | Potential : potential nonkinetic
+type _ nonchemical = Kinetic : kinetic nonchemical | Potential : potential nonchemical

--- a/lib/core/equal.ml
+++ b/lib/core/equal.ml
@@ -47,7 +47,7 @@ and equal_at : int -> kinetic value -> kinetic value -> kinetic value -> unit op
   | Neu { alignment = Lawful (Codata { eta = Noeta; fields; _ }); _ } -> (
       (* At a record-type without eta, two structs are equal if their insertions and corresponding fields are equal, and a struct is not equal to any other term.  We have to handle these cases here, though, because once we get to equal_val we don't have the type information, which is not stored in a struct. *)
       match (x, y) with
-      | Struct (xfld, xins), Struct (yfld, yins) ->
+      | Struct (xfld, xins, _), Struct (yfld, yins, _) ->
           let* () = deg_equiv (perm_of_ins xins) (perm_of_ins yins) in
           BwdM.miterM
             (fun [ (fld, _) ] ->
@@ -55,12 +55,12 @@ and equal_at : int -> kinetic value -> kinetic value -> kinetic value -> unit op
                 match Abwd.find_opt fld xfld with
                 | Some xv -> xv
                 | None -> fatal (Anomaly "missing field in equality-check") in
-              let (Val xtm) = Lazy.force (fst xv) in
+              let (Val (xtm, _)) = Lazy.force (fst xv) in
               let yv =
                 match Abwd.find_opt fld yfld with
                 | Some yv -> yv
                 | None -> fatal (Anomaly "missing field in equality-check") in
-              let (Val ytm) = Lazy.force (fst yv) in
+              let (Val (ytm, _)) = Lazy.force (fst yv) in
               equal_at ctx xtm ytm (tyof_field x ty fld))
             [ fields ]
       | Struct _, _ | _, Struct _ -> fail

--- a/lib/core/meta.ml
+++ b/lib/core/meta.ml
@@ -54,6 +54,7 @@ module Map = struct
       type ('b, 'g) t = {
         kinetic : ('b, 'g * kinetic) F.t IntMap.t;
         potential : ('b, 'g * potential) F.t IntMap.t;
+        chemical : ('b, 'g * chemical) F.t IntMap.t;
       }
     end
 
@@ -71,6 +72,7 @@ module Map = struct
        fun s i eimap ->
         match s with
         | Kinetic -> IntMap.find_opt i eimap.kinetic
+        | Chemical -> IntMap.find_opt i eimap.chemical
         | Potential -> IntMap.find_opt i eimap.potential in
       let (MetaKey m) = key in
       let* eimap = Map.find_opt m.len map in
@@ -82,13 +84,16 @@ module Map = struct
        fun s i value eimap ->
         match s with
         | Kinetic -> { eimap with kinetic = IntMap.add i value eimap.kinetic }
+        | Chemical -> { eimap with chemical = IntMap.add i value eimap.chemical }
         | Potential -> { eimap with potential = IntMap.add i value eimap.potential } in
       let (MetaKey m) = key in
       Map.update m.len
         (function
           | Some eimap -> Some (go m.energy m.number value eimap)
           | None ->
-              Some (go m.energy m.number value { kinetic = IntMap.empty; potential = IntMap.empty }))
+              Some
+                (go m.energy m.number value
+                   { kinetic = IntMap.empty; chemical = IntMap.empty; potential = IntMap.empty }))
         map
 
     let update : type b g. g Key.t -> ((b, g) F.t option -> (b, g) F.t option) -> b t -> b t =
@@ -103,13 +108,16 @@ module Map = struct
        fun s i f eimap ->
         match s with
         | Kinetic -> { eimap with kinetic = IntMap.update i f eimap.kinetic }
+        | Chemical -> { eimap with chemical = IntMap.update i f eimap.chemical }
         | Potential -> { eimap with potential = IntMap.update i f eimap.potential } in
       let (MetaKey m) = key in
       Map.update m.len
         (function
           | Some eimap -> Some (go m.energy m.number f eimap)
           | None ->
-              Some (go m.energy m.number f { kinetic = IntMap.empty; potential = IntMap.empty }))
+              Some
+                (go m.energy m.number f
+                   { kinetic = IntMap.empty; chemical = IntMap.empty; potential = IntMap.empty }))
         map
 
     let remove : type b g. g Key.t -> b t -> b t =
@@ -118,6 +126,7 @@ module Map = struct
        fun s i eimap ->
         match s with
         | Kinetic -> { eimap with kinetic = IntMap.remove i eimap.kinetic }
+        | Chemical -> { eimap with chemical = IntMap.remove i eimap.chemical }
         | Potential -> { eimap with potential = IntMap.remove i eimap.potential } in
       let (MetaKey m) = key in
       Map.update m.len

--- a/lib/core/reporter.ml
+++ b/lib/core/reporter.ml
@@ -130,6 +130,7 @@ module Code = struct
     | Open_holes : t
     | Quit : t
     | Synthesizing_recursion : printable -> t
+    | Invalid_synthesized_type : string * printable -> t
 
   (** The default severity of messages with a particular message code. *)
   let default_severity : t -> Asai.Diagnostic.severity = function
@@ -223,6 +224,7 @@ module Code = struct
     | Open_holes -> Error
     | Quit -> Info
     | Synthesizing_recursion _ -> Error
+    | Invalid_synthesized_type _ -> Error
 
   (** A short, concise, ideally Google-able string representation for each message code. *)
   let short_code : t -> string = function
@@ -255,6 +257,7 @@ module Code = struct
     | Unequal_synthesized_type _ -> "E0401"
     | Synthesizing_recursion _ -> "E0402"
     | Invalid_outside_case_tree _ -> "E0403"
+    | Invalid_synthesized_type _ -> "E0404"
     (* Dimensions *)
     | Dimension_mismatch _ -> "E0500"
     | Not_enough_lambdas _ -> "E0501"
@@ -557,6 +560,8 @@ module Code = struct
     | Quit -> text "Goodbye!"
     | Synthesizing_recursion c ->
         textf "for '%a' to be recursive, it must have a declared type" pp_printed (print c)
+    | Invalid_synthesized_type (str, ty) ->
+        textf "type %a synthesized by %s is invalid for entire term" pp_printed (print ty) str
 end
 
 include Asai.StructuredReporter.Make (Code)

--- a/lib/parser/builtins.ml
+++ b/lib/parser/builtins.ml
@@ -764,7 +764,8 @@ let () =
               match (process ctx tm).value with
               | Synth value ->
                   {
-                    value = Match ({ value; loc = tm.loc }, `Implicit, process_branches ctx obs);
+                    value =
+                      Synth (Match ({ value; loc = tm.loc }, `Implicit, process_branches ctx obs));
                     loc;
                   }
               | _ -> fatal ?loc:tm.loc (Nonsynthesizing "discriminee of match"))
@@ -782,17 +783,20 @@ let () =
                     let (Extctx (mn, _, _)) = get_vars ctx vars in
                     {
                       value =
-                        Match
-                          ( { value; loc = tm.loc },
-                            `Nondep { value = N.to_int (N.plus_right mn); loc = vars.loc },
-                            process_branches ctx obs );
+                        Synth
+                          (Match
+                             ( { value; loc = tm.loc },
+                               `Nondep { value = N.to_int (N.plus_right mn); loc = vars.loc },
+                               process_branches ctx obs ));
                       loc;
                     }
                 | Synth value, _ ->
                     let motive = process ctx motive in
                     {
                       value =
-                        Match ({ value; loc = tm.loc }, `Explicit motive, process_branches ctx obs);
+                        Synth
+                          (Match
+                             ({ value; loc = tm.loc }, `Explicit motive, process_branches ctx obs));
                       loc;
                     }
                 | _ -> fatal ?loc:tm.loc (Nonsynthesizing "discriminee of match")
@@ -810,7 +814,8 @@ let () =
                 ( { value = None; loc = None },
                   `Normal,
                   {
-                    value = Match ({ value = Var (Top, None); loc = None }, `Implicit, branches);
+                    value =
+                      Synth (Match ({ value = Var (Top, None); loc = None }, `Implicit, branches));
                     loc;
                   } );
             loc;

--- a/lib/parser/command.ml
+++ b/lib/parser/command.ml
@@ -339,7 +339,7 @@ let execute : Command.t -> unit = function
       let rtm = process Emp tm in
       match rtm.value with
       | Synth stm ->
-          let ctm, ety = Check.synth Ctx.empty { value = stm; loc = rtm.loc } in
+          let ctm, ety = Check.synth Kinetic Ctx.empty { value = stm; loc = rtm.loc } in
           let etm = Norm.eval_term (Emp D.zero) ctm in
           let btm = Readback.readback_at Ctx.empty etm ety in
           let bty = Readback.readback_at Ctx.empty ety (Inst.universe D.zero) in

--- a/lib/util/perhaps.ml
+++ b/lib/util/perhaps.ml
@@ -1,0 +1,9 @@
+(* A version of "option" that takes a type parameter determining whether it has an element or not.  This allows, for instance, the return type of a function to vary predictably depending on whether some argument was supplied. *)
+
+type none = private Dummy_none
+type some = private Dummy_some
+
+module Perhaps = struct
+  type (_, _) t = None : ('a, none) t | Some : 'a -> ('a, some) t
+  type (_, _) not = Not_none : 'a -> ('a, none) not | Not_some : ('a, some) not
+end

--- a/test/black/letin.t
+++ b/test/black/letin.t
@@ -228,3 +228,59 @@ Let is allowed in case trees:
   atree
     : A → A
   
+
+Matches and other lets in let-bindings
+
+  $ cat >chem.ny <<EOF
+  > def bool : Type := data [ true. | false. ]
+  > def not1 (b : bool) : bool := let n : bool := match b [ true. |-> false. | false. |-> true. ] in n
+  > echo not1 true.
+  > echo not1 false.
+  > def not2 (b : bool) : bool := let n := match b [ true. |-> false. : bool | false. |-> true. ] in n
+  > echo not2 true.
+  > echo not2 false.
+  > def not3 (b : bool) : bool := let n := let m := match b [ true. |-> false. : bool | false. |-> true. ] in m in n
+  > echo not3 true.
+  > echo not3 false.
+
+  $ narya -v chem.ny
+   ￫ info[I0000]
+   ￮ Constant bool defined
+  
+   ￫ info[I0000]
+   ￮ Constant not1 defined
+  
+  false.
+    : bool
+  
+  true.
+    : bool
+  
+   ￫ hint[E1101]
+   ￭ chem.ny
+   5 | def not2 (b : bool) : bool := let n := match b [ true. |-> false. : bool | false. |-> true. ] in n
+     ^ match will not refine the goal or context (match in synthesizing position): 
+  
+   ￫ info[I0000]
+   ￮ Constant not2 defined
+  
+  false.
+    : bool
+  
+  true.
+    : bool
+  
+   ￫ hint[E1101]
+   ￭ chem.ny
+   8 | def not3 (b : bool) : bool := let n := let m := match b [ true. |-> false. : bool | false. |-> true. ] in m in n
+     ^ match will not refine the goal or context (match in synthesizing position): 
+  
+   ￫ info[I0000]
+   ￮ Constant not3 defined
+  
+  false.
+    : bool
+  
+  true.
+    : bool
+  

--- a/test/testutil/mcp.ml
+++ b/test/testutil/mcp.ml
@@ -33,7 +33,7 @@ let synth (tm : string) : kinetic value * kinetic value =
   @@ fun () ->
   match parse_term names tm with
   | { value = Synth raw; loc } ->
-      let syn, ty = Check.synth ctx { value = raw; loc } in
+      let syn, ty = Check.synth Kinetic ctx { value = raw; loc } in
       let esyn = Ctx.eval_term ctx syn in
       (esyn, ty)
   | _ -> Reporter.fatal (Nonsynthesizing "toplevel synth")
@@ -69,7 +69,7 @@ let unsynth : ?print:unit -> ?code:Reporter.Code.t -> ?short:string -> string ->
   @@ fun () ->
   match parse_term names tm with
   | { value = Synth raw; loc } ->
-      let _ = Check.synth ctx { value = raw; loc } in
+      let _ = Check.synth Kinetic ctx { value = raw; loc } in
       raise (Failure "Synthesis success")
   | _ -> Reporter.fatal (Nonsynthesizing "top-level unsynth")
 

--- a/test/testutil/pmp.ml
+++ b/test/testutil/pmp.ml
@@ -108,7 +108,7 @@ let synth (tm : pmt) : kinetic value * kinetic value =
       raise (Failure "Failed to synthesize"))
   @@ fun () ->
   let raw = parse_syn names tm in
-  let syn, ty = Check.synth ctx raw in
+  let syn, ty = Check.synth Kinetic ctx raw in
   let esyn = Ctx.eval_term ctx syn in
   (esyn, ty)
 
@@ -128,7 +128,7 @@ let unsynth (tm : pmt) : unit =
   let (Ctx (ctx, names)) = !context in
   Reporter.run ~emit:Terminal.display ~fatal:(fun _ -> ()) @@ fun () ->
   let raw = parse_syn names tm in
-  let _ = Check.synth ctx raw in
+  let _ = Check.synth Kinetic ctx raw in
   raise (Failure "Synthesis success")
 
 let uncheck (tm : pmt) (ty : kinetic value) : unit =

--- a/test/testutil/repl.ml
+++ b/test/testutil/repl.ml
@@ -116,7 +116,7 @@ let print (tm : string) : unit =
   let rtm = parse_term tm in
   match rtm with
   | { value = Synth rtm; loc } ->
-      let ctm, ety = synth Ctx.empty { value = rtm; loc } in
+      let ctm, ety = synth Kinetic Ctx.empty { value = rtm; loc } in
       let etm = eval_term (Emp D.zero) ctm in
       let btm = readback_at Ctx.empty etm ety in
       let utm = unparse Names.empty btm Interval.entire Interval.entire in


### PR DESCRIPTION
This change allows the term *bound* by a let-binding in a case tree to itself contain matches and other such let-bindings.  I thought this would be nice for programming because in OCaml I often find myself putting matches in let-bindings.  A case tree containing such a binding doesn't evaluate unless the match-containing term in the let-binding evaluates fully to an ordinary term (no more matches) -- hence why other kinds of case tree nodes are not allowed therein, as they could never evaluate fully until they are applied to a further argument or field/method.

The implementation of this unfortunately required some changes touching a lot of other things, including introducing a new kind of term in addition to "kinetic" and "potential" (which I called "chemical" since it is a subclass of "potential" that involves "breaking things apart" with matches).  So I'm pausing a bit before merging it to master, to make sure I think it is worth the extra complication.  Feedback from anyone who happens to be watching is welcome.