### PR TITLE
Import files

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ In a file, conventionally each command begins on a new line, but this is not tec
 
 5. `import FILE`
 
-   Execute the file at location `FILE`, which must be specified as a double-quoted string (either absolute or relative to the location of the current file), and import its definitions and notations into the current namespace.  The commands in `FILE` do not have access to any other definitions except those from other files that it `require`s, and the definitions and notations from files `require`d by `FILE` are not imported into the current namespace (unless those files are also `require`d by the current file).  No file will be executed more than during a single run, even if it is `require`d by multiple other files.  Circular dependencies are not allowed.
-   
-   The syntax and behavior of this command is very likely to change in the future, as we add support for library resolution and namespace management.  The present version is just a stand-in that gives low-level access to the primitive "loading a file from the filesystem" functionality.
+   Add the extension `.ny` to the double-quoted string `FILE`, execute the file at that location (either absolute or relative to the location of the current file), and add its definitions and notations to the current namespace.  That is, the disk file *must* have the `.ny` extension, whereas the string given to `import` must *not* have it; this is because in the future the string given to `import` will be a more general "library identifier" in the [bantorra](https://redprl.org/bantorra/bantorra/index.html) framework.
+
+   The commands in `FILE.ny` cannot access any definitions from other files, including the current one, except those that it imports itself; and the definitions and notations from files imported by `FILE.ny` are not added to the current namespace (unless it also imports those files directly).  No file will be executed more than once during a single run, even if it is imported by multiple other files.  Circular imports are not allowed.
 
 6. `quit`
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ In a file, conventionally each command begins on a new line, but this is not tec
 
 6. `quit`
 
-   Terminate execution immediately.  Whenever this command is found, loading of the current file or command-line string ceases, no further files or strings will be loaded, and interactive mode will be exited or skipped.  (You can also exit interactive mode by typing Control+D.)
+   Terminate execution of the current compilation unit.  Whenever this command is found, loading of the current file or command-line string ceases, just as if the file or string had ended right there.  Execution then continues as usual with any file that imported the current one, with the next file or string on the command line, or with interactive mode if that was requested.  The command `quit` in interactive mode exits the program (you can also exit interactive mode by typing Control+D).
    
 
 ## Built-in types

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ In interactive mode, commands typed by the user are executed as they are entered
 
 ### Commands
 
-In a file, conventionally each command begins on a new line, but this is not technically necessary since each command begins with a keyword that has no other meaning.  Indentation is not significant, but a standard reformatter (like `ocamlformat`) is planned so that the default will be to enforce a uniform indentation style.  (Experimental output of this reformatter-in-progress is available with the `-reformat` command-line option.)  So far, the available commands are:
+In a file, conventionally each command begins on a new line, but this is not technically necessary since each command begins with a keyword that has no other meaning.  (Similarly, a command-line `-e` string may contain multiple commands as long as whitespace separates them.)  Indentation is not significant, but a standard reformatter (like `ocamlformat`) is planned so that the default will be to enforce a uniform indentation style.  (Experimental output of this reformatter-in-progress is available with the `-reformat` command-line option.)  So far, the available commands are:
 
 1. `def NAME [PARAMS] [: TYPE] ≔ TERM [and ...]`
 
@@ -82,7 +82,9 @@ In a file, conventionally each command begins on a new line, but this is not tec
 
 5. `require FILE`
 
-   Execute the file `FILE`, which must be specified as a double-quoted string, and import its definitions into the current namespace.  This is like copying the contents of that file into the current one, except that (1) no file will be executed more than during a single run, and (2) while other files required by that file will also be executed (if they haven't yet been), their definitions are not imported into the *current* namespace.  The filename `FILE` can be either absolute, or relative to the location of the file currently being loaded.  Circular dependencies are not allowed.
+   Execute the file at location `FILE`, which must be specified as a double-quoted string (either absolute or relative to the location of the current file), and import its definitions and notations into the current namespace.  The commands in `FILE` do not have access to any other definitions except those from other files that it `require`s, and the definitions and notations from files `require`d by `FILE` are not imported into the current namespace (unless those files are also `require`d by the current file).  No file will be executed more than during a single run, even if it is `require`d by multiple other files.  Circular dependencies are not allowed.
+   
+   The syntax and behavior of this command is very likely to change in the future, as we add support for library resolution and namespace management.  The present version is just a stand-in that gives low-level access to the primitive "loading a file from the filesystem" functionality.
 
 6. `quit`
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ These options are discussed further below.
 
 When the Narya executable is run, it loads all the files given on its command line and any strings supplied on the command line with `-e`.  As usual, the special filename `-` refers to standard input.  Files and strings are loaded in the order they are given on the command line.  Lastly, if `-i` was given anywhere on the command line, Narya enters interactive mode.
 
-There is currently no importing or exporting: all definitions from all sources go into the same flat namespace, so for instance in interactive mode you can refer to definitions made in files that were loaded previously.  There is also no compilation or caching: everything must be typechecked and loaded anew at every invocation.
+When in interactive mode or loading a command-line `-e` string, all definitions from all files and strings specified previously on the command line are available (but not those loaded transitively by `require`).  However, when loading a file (including standard input), definitions from other files are not available by default, even if those files were specified earlier on the command line; you have to explicitly `require` them (see below).  There is no compilation or caching yet: everything must be typechecked and loaded anew at every invocation.
 
 In interactive mode, commands typed by the user are executed as they are entered.  Since many commands span multiple lines, Narya waits for a blank line before parsing and executing the command(s) being entered.  Make sure to enter a blank line before starting a new command; interactive commands must be entered and executed one at a time.  The result of the command is printed (more verbosely than is usual when loading a file) and then the user can enter more commands.  Type Control+D to exit interactive mode, or enter the command `quit`.  In addition, in interactive mode you can enter a term instead of a command, and Narya will assume you mean to `echo` it (see below).
 
@@ -80,7 +80,11 @@ In a file, conventionally each command begins on a new line, but this is not tec
 
    Declare a new mixfix notation.  Every notation must have a `NAME`, which is an identifier like the name of a constant, and a `TIGHTNESS` unless it is outfix (see below).  The `PATTERN` of a notation is discussed below.  The value of a notation consists of a `HEAD`, which is either a previously defined constant or a datatype constructor (see below), followed by the `ARGUMENTS` that must consist of exactly the variables appearing in the pattern, once each, in some order.
 
-5. `quit`
+5. `require FILE`
+
+   Execute the file `FILE`, which must be specified as a double-quoted string, and import its definitions into the current namespace.  This is like copying the contents of that file into the current one, except that (1) no file will be executed more than during a single run, and (2) while other files required by that file will also be executed (if they haven't yet been), their definitions are not imported into the *current* namespace.  The filename `FILE` can be either absolute, or relative to the location of the file currently being loaded.  Circular dependencies are not allowed.
+
+6. `quit`
 
    Terminate execution immediately.  Whenever this command is found, loading of the current file or command-line string ceases, no further files or strings will be loaded, and interactive mode will be exited or skipped.  (You can also exit interactive mode by typing Control+D.)
    

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ These options are discussed further below.
 
 When the Narya executable is run, it loads all the files given on its command line and any strings supplied on the command line with `-e`.  As usual, the special filename `-` refers to standard input.  Files and strings are loaded in the order they are given on the command line.  Lastly, if `-i` was given anywhere on the command line, Narya enters interactive mode.
 
-When in interactive mode or loading a command-line `-e` string, all definitions from all files and strings specified previously on the command line are available (but not those loaded transitively by `require`).  However, when loading a file (including standard input), definitions from other files are not available by default, even if those files were specified earlier on the command line; you have to explicitly `require` them (see below).  There is no compilation or caching yet: everything must be typechecked and loaded anew at every invocation.
+When in interactive mode or loading a command-line `-e` string, all definitions from all files and strings specified previously on the command line are available (but not those loaded transitively by `import`).  However, when loading a file (including standard input), definitions from other files are not available by default, even if those files were specified earlier on the command line; you have to explicitly `import` them (see below).  There is no compilation or caching yet: everything must be typechecked and loaded anew at every invocation.
 
 In interactive mode, commands typed by the user are executed as they are entered.  Since many commands span multiple lines, Narya waits for a blank line before parsing and executing the command(s) being entered.  Make sure to enter a blank line before starting a new command; interactive commands must be entered and executed one at a time.  The result of the command is printed (more verbosely than is usual when loading a file) and then the user can enter more commands.  Type Control+D to exit interactive mode, or enter the command `quit`.  In addition, in interactive mode you can enter a term instead of a command, and Narya will assume you mean to `echo` it (see below).
 
@@ -80,7 +80,7 @@ In a file, conventionally each command begins on a new line, but this is not tec
 
    Declare a new mixfix notation.  Every notation must have a `NAME`, which is an identifier like the name of a constant, and a `TIGHTNESS` unless it is outfix (see below).  The `PATTERN` of a notation is discussed below.  The value of a notation consists of a `HEAD`, which is either a previously defined constant or a datatype constructor (see below), followed by the `ARGUMENTS` that must consist of exactly the variables appearing in the pattern, once each, in some order.
 
-5. `require FILE`
+5. `import FILE`
 
    Execute the file at location `FILE`, which must be specified as a double-quoted string (either absolute or relative to the location of the current file), and import its definitions and notations into the current namespace.  The commands in `FILE` do not have access to any other definitions except those from other files that it `require`s, and the definitions and notations from files `require`d by `FILE` are not imported into the current namespace (unless those files are also `require`d by the current file).  No file will be executed more than during a single run, even if it is `require`d by multiple other files.  Circular dependencies are not allowed.
    

--- a/bin/narya.ml
+++ b/bin/narya.ml
@@ -195,7 +195,6 @@ let () =
   Parser.Unparse.install ();
   Eternity.run_empty @@ fun () ->
   Global.run_empty @@ fun () ->
-  Scope.run @@ fun () ->
   Builtins.run @@ fun () ->
   Printconfig.run
     ~env:
@@ -205,6 +204,8 @@ let () =
         chars = (if !unicode then `Unicode else `ASCII);
       }
   @@ fun () ->
+  Readback.Display.run ~env:false @@ fun () ->
+  Core.Syntax.Discreteness.run ~env:!discreteness @@ fun () ->
   Reporter.run
     ~emit:(fun d ->
       if !verbose || d.severity = Error || d.severity = Warning then
@@ -213,15 +214,14 @@ let () =
       Terminal.display ~output:stderr d;
       exit 1)
   @@ fun () ->
-  Readback.Display.run ~env:false @@ fun () ->
-  Core.Syntax.Discreteness.run ~env:!discreteness @@ fun () ->
-  Parser.Pi.install ();
   if !arity < 1 || !arity > 9 then Reporter.fatal (Unimplemented "arities outside [1,9]");
   if !discreteness && !arity > 1 then Reporter.fatal (Unimplemented "discreteness with arity > 1");
   Dim.Endpoints.set_len !arity;
   Dim.Endpoints.set_char !refl_char;
   Dim.Endpoints.set_names !refl_strings;
   Dim.Endpoints.set_internal !internal;
+  let init_visible = Parser.Pi.install Scope.Trie.empty in
+  Scope.run ~init_visible @@ fun () ->
   (* TODO: If executing multiple files, they should be namespaced as sections.  (And eventually, using bantorra.) *)
   Mbwd.miter
     (fun [ input ] ->

--- a/lib/core/reporter.ml
+++ b/lib/core/reporter.ml
@@ -556,10 +556,10 @@ module Code = struct
               (fun ppf names ->
                 pp_print_list
                   (fun ppf (name, discrete) ->
-                    pp_printed ppf (print name);
+                    pp_printed ppf name;
                     if discrete then pp_print_string ppf " (discrete)")
                   ppf names)
-              names)
+              (List.map (fun (name, discrete) -> (print name, discrete)) names))
     | Notation_defined name -> textf "Notation %s defined" name
     | Show (str, x) -> textf "%s: %a" str pp_printed (print x)
     | Comment_end_in_string ->

--- a/lib/core/reporter.ml
+++ b/lib/core/reporter.ml
@@ -140,7 +140,7 @@ module Code = struct
     | Invalid_refutation : t
     | Duplicate_pattern_variable : string -> t
     | Type_expected : string -> t
-    | Circular_dependency : string list -> t
+    | Circular_import : string list -> t
     | Loading_file : string -> t
     | File_loaded : string -> t
 
@@ -246,7 +246,7 @@ module Code = struct
     | Invalid_refutation -> Error
     | Duplicate_pattern_variable _ -> Error
     | Type_expected _ -> Error
-    | Circular_dependency _ -> Error
+    | Circular_import _ -> Error
     | Loading_file _ -> Info
     | File_loaded _ -> Info
 
@@ -366,8 +366,8 @@ module Code = struct
     | Notation_variable_used_twice _ -> "E2209"
     | Unbound_variable_in_notation _ -> "E2210"
     | Head_already_has_notation _ -> "E2211"
-    (* require *)
-    | Circular_dependency _ -> "E2300"
+    (* import *)
+    | Circular_import _ -> "E2300"
     (* Interactive proof *)
     | Open_holes -> "E3000"
     (* Command progress and success *)
@@ -619,12 +619,12 @@ module Code = struct
     | Duplicate_pattern_variable x ->
         textf "variable name '%s' used more than once in match patterns" x
     | Type_expected str -> textf "expected type while %s" str
-    | Circular_dependency files ->
-        textf "circular dependency:@,@[<v 2>%a@]"
+    | Circular_import files ->
+        textf "circular imports:@,@[<v 2>%a@]"
           (pp_print_list
              ~pp_sep:(fun ppf () ->
                pp_print_cut ppf ();
-               pp_print_string ppf "requires ")
+               pp_print_string ppf "imports ")
              pp_print_string)
           files
     | Loading_file file -> textf "loading file: %s" file

--- a/lib/core/reporter.ml
+++ b/lib/core/reporter.ml
@@ -98,7 +98,7 @@ module Code = struct
     | Unsupported_numeral : Q.t -> t
     | Anomaly : string -> t
     | No_such_level : printable -> t
-    | Constant_already_defined : string -> t
+    | Name_already_defined : string -> t
     | Invalid_constant_name : string -> t
     | Too_many_commands : t
     | Invalid_tightness : string -> t
@@ -204,7 +204,7 @@ module Code = struct
     | Unsupported_numeral _ -> Error
     | Anomaly _ -> Bug
     | No_such_level _ -> Bug
-    | Constant_already_defined _ -> Warning
+    | Name_already_defined _ -> Warning
     | Invalid_constant_name _ -> Error
     | Too_many_commands -> Error
     | Invalid_tightness _ -> Error
@@ -351,7 +351,7 @@ module Code = struct
     (* Commands *)
     | Too_many_commands -> "E2000"
     (* def *)
-    | Constant_already_defined _ -> "E2100"
+    | Name_already_defined _ -> "E2100"
     | Invalid_constant_name _ -> "E2101"
     (* notation *)
     | Invalid_tightness _ -> "E2200"
@@ -526,7 +526,7 @@ module Code = struct
     | Unsupported_numeral n -> textf "unsupported numeral: %a" Q.pp_print n
     | Anomaly str -> textf "anomaly: %s" str
     | No_such_level i -> textf "@[<hov 2>no level variable@ %a@ in context@]" pp_printed (print i)
-    | Constant_already_defined name -> textf "redefining constant: %a" pp_utf_8 name
+    | Name_already_defined name -> textf "name already defined: %a" pp_utf_8 name
     | Invalid_constant_name name -> textf "invalid constant name: %a" pp_utf_8 name
     | Too_many_commands -> text "too many commands: enter one at a time"
     | Fixity_mismatch ->

--- a/lib/core/reporter.ml
+++ b/lib/core/reporter.ml
@@ -128,7 +128,7 @@ module Code = struct
     | Locked_axiom : printable -> t
     | Hole_generated : ('b, 's) Meta.t * printable -> t
     | Open_holes : t
-    | Quit : t
+    | Quit : string option -> t
     | Synthesizing_recursion : printable -> t
     | Invalid_synthesized_type : string * printable -> t
     | Unrecognized_attribute : t
@@ -235,7 +235,7 @@ module Code = struct
     | Locked_axiom _ -> Error
     | Hole_generated _ -> Info
     | Open_holes -> Error
-    | Quit -> Info
+    | Quit _ -> Info
     | Synthesizing_recursion _ -> Error
     | Invalid_synthesized_type _ -> Error
     | Unrecognized_attribute -> Error
@@ -382,7 +382,7 @@ module Code = struct
     (* Events during command execution *)
     | Hole_generated _ -> "I0100"
     (* Control of execution *)
-    | Quit -> "I0200"
+    | Quit _ -> "I0200"
     (* Debugging *)
     | Show _ -> "I9999"
 
@@ -604,8 +604,9 @@ module Code = struct
     | Locked_axiom a -> textf "axiom %a locked behind external degeneracy" pp_printed (print a)
     | Hole_generated (n, ty) ->
         textf "@[<v 0>hole %s generated:@,@,%a@]" (Meta.name n) pp_printed (print ty)
-    | Open_holes -> text "There are open holes"
-    | Quit -> text "Goodbye!"
+    | Open_holes -> text "there are open holes"
+    | Quit (Some src) -> textf "execution of %s terminated by quit" src
+    | Quit None -> text "execution terminated by quit"
     | Synthesizing_recursion c ->
         textf "for '%a' to be recursive, it must have a declared type" pp_printed (print c)
     | Invalid_synthesized_type (str, ty) ->

--- a/lib/core/reporter.ml
+++ b/lib/core/reporter.ml
@@ -143,6 +143,7 @@ module Code = struct
     | Circular_import : string list -> t
     | Loading_file : string -> t
     | File_loaded : string -> t
+    | Library_has_extension : string -> t
 
   (** The default severity of messages with a particular message code. *)
   let default_severity : t -> Asai.Diagnostic.severity = function
@@ -249,6 +250,7 @@ module Code = struct
     | Circular_import _ -> Error
     | Loading_file _ -> Info
     | File_loaded _ -> Info
+    | Library_has_extension _ -> Warning
 
   (** A short, concise, ideally Google-able string representation for each message code. *)
   let short_code : t -> string = function
@@ -368,6 +370,7 @@ module Code = struct
     | Head_already_has_notation _ -> "E2211"
     (* import *)
     | Circular_import _ -> "E2300"
+    | Library_has_extension _ -> "W2301"
     (* Interactive proof *)
     | Open_holes -> "E3000"
     (* Command progress and success *)
@@ -629,6 +632,7 @@ module Code = struct
           files
     | Loading_file file -> textf "loading file: %s" file
     | File_loaded file -> textf "file loaded: %s" file
+    | Library_has_extension file -> textf "putative library name '%s' has extension" file
 end
 
 include Asai.StructuredReporter.Make (Code)

--- a/lib/parser/command.ml
+++ b/lib/parser/command.ml
@@ -396,10 +396,16 @@ let execute : Command.t -> unit = function
           (args, []) pattern in
       if not (List.is_empty unbound) then
         fatal (Unbound_variable_in_notation (List.map fst unbound));
-      let n =
+      let key, notn, shadow =
         State.Current.add_user (String.concat "." name) fixity pattern head (List.map fst args)
       in
-      Scope.include_singleton (notation_name, (`Notation n, ()));
+      Scope.include_singleton (notation_name, (`Notation (key, notn), ()));
+      (if shadow then
+         let keyname =
+           match key with
+           | `Constr (c, _) -> Constr.to_string c ^ "."
+           | `Constant c -> String.concat "." (Scope.name_of c) in
+         emit (Head_already_has_notation keyname));
       emit (Notation_defined (String.concat "." name))
   | Require { file; _ } ->
       let trie = Units.get (`File file) false in

--- a/lib/parser/command.ml
+++ b/lib/parser/command.ml
@@ -50,6 +50,7 @@ module Command = struct
         args : (string * Whitespace.t list) list;
       }
         -> t
+    | Require of { wsreq : Whitespace.t list; file : string; wsfile : Whitespace.t list }
     | Quit of Whitespace.t list
     | Bof of Whitespace.t list
     | Eof
@@ -213,6 +214,13 @@ module Parse = struct
            args;
          })
 
+  let require =
+    let* wsreq = token Require in
+    step "" (fun state _ (tok, wsfile) ->
+        match tok with
+        | String file -> Some (Require { wsreq; file; wsfile }, state)
+        | _ -> None)
+
   let quit =
     let* wsquit = token Quit in
     return (Command.Quit wsquit)
@@ -225,7 +233,7 @@ module Parse = struct
     let* () = expect_end () in
     return Command.Eof
 
-  let command () = bof </> axiom </> def_and </> echo </> notation </> quit </> eof
+  let command () = bof </> axiom </> def_and </> echo </> notation </> require </> quit </> eof
 
   let command_or_echo () =
     command ()
@@ -389,6 +397,9 @@ let execute : Command.t -> unit = function
         fatal (Unbound_variable_in_notation (List.map fst unbound));
       State.Current.add_user (String.concat "." name) fixity pattern head (List.map fst args);
       emit (Notation_defined (String.concat "." name))
+  | Require { file; _ } ->
+      let trie = Scope.get_unit (`File file) false in
+      Scope.import_subtree ([], trie)
   | Quit _ -> fatal Quit
   | Bof _ -> ()
   | Eof -> fatal (Anomaly "EOF cannot be executed")
@@ -546,6 +557,17 @@ let pp_command : formatter -> t -> Whitespace.t list =
             let wslast, rest = Whitespace.split wslast in
             pp_ws `None ppf wslast;
             rest in
+      pp_close_box ppf ();
+      rest
+  | Require { wsreq; file; wsfile } ->
+      pp_open_hvbox ppf 2;
+      pp_tok ppf Require;
+      pp_ws `Nobreak ppf wsreq;
+      pp_print_string ppf "\"";
+      pp_print_string ppf file;
+      pp_print_string ppf "\"";
+      let ws, rest = Whitespace.split wsfile in
+      pp_ws `None ppf ws;
       pp_close_box ppf ();
       rest
   | Quit ws -> ws

--- a/lib/parser/command.ml
+++ b/lib/parser/command.ml
@@ -412,7 +412,7 @@ let execute : Command.t -> unit = function
       let file = FilePath.add_extension file "ny" in
       let trie = Units.get (`File file) false in
       Scope.import_subtree ([], trie)
-  | Quit _ -> fatal Quit
+  | Quit _ -> fatal (Quit None)
   | Bof _ -> ()
   | Eof -> fatal (Anomaly "EOF cannot be executed")
 

--- a/lib/parser/command.ml
+++ b/lib/parser/command.ml
@@ -10,10 +10,11 @@ open Format
 open Uuseg_string
 open Print
 open Reporter
+module Trie = Yuujinchou.Trie
 
 type def = {
   wsdef : Whitespace.t list;
-  name : Scope.Trie.path;
+  name : Trie.path;
   wsname : Whitespace.t list;
   parameters : Parameter.t list;
   wscolon : Whitespace.t list;
@@ -26,7 +27,7 @@ module Command = struct
   type t =
     | Axiom of {
         wsaxiom : Whitespace.t list;
-        name : Scope.Trie.path;
+        name : Trie.path;
         wsname : Whitespace.t list;
         parameters : Parameter.t list;
         wscolon : Whitespace.t list;
@@ -39,12 +40,12 @@ module Command = struct
         wsnotation : Whitespace.t list;
         wstight : Whitespace.t list; (* Empty for outfix *)
         wsellipsis : Whitespace.t list; (* Empty for non-associative *)
-        name : Scope.Trie.path;
+        name : Trie.path;
         wsname : Whitespace.t list;
         wscolon : Whitespace.t list;
         pattern : State.pattern;
         wscoloneq : Whitespace.t list;
-        head : [ `Constr of string | `Constant of Scope.Trie.path ];
+        head : [ `Constr of string | `Constant of Trie.path ];
         wshead : Whitespace.t list;
         args : (string * Whitespace.t list) list;
       }
@@ -120,8 +121,8 @@ module Parse = struct
     let* tm = C.term [] in
     return (Command.Echo { wsecho; tm })
 
-  let tightness_and_name :
-      (No.wrapped option * Whitespace.t list * Scope.Trie.path * Whitespace.t list) t =
+  let tightness_and_name : (No.wrapped option * Whitespace.t list * Trie.path * Whitespace.t list) t
+      =
     let* tloc, tight_or_name = located ident in
     (let* name, wsname = ident in
      let tight, wstight = tight_or_name in
@@ -292,8 +293,8 @@ let execute : Command.t -> unit = function
         emit (Constant_already_defined (String.concat "." name));
       let const = Scope.define name in
       Reporter.try_with ~fatal:(fun d ->
-          Scope.S.modify_visible (Yuujinchou.Language.except name);
-          Scope.S.modify_export (Yuujinchou.Language.except name);
+          Scope.modify_visible (Yuujinchou.Language.except name);
+          Scope.modify_export (Yuujinchou.Language.except name);
           Reporter.fatal_diagnostic d)
       @@ fun () ->
       let (Processed_tel (params, ctx)) = process_tel Emp parameters in
@@ -310,8 +311,8 @@ let execute : Command.t -> unit = function
       Reporter.try_with ~fatal:(fun d ->
           List.iter
             (fun c ->
-              Scope.S.modify_visible (Yuujinchou.Language.except c);
-              Scope.S.modify_export (Yuujinchou.Language.except c))
+              Scope.modify_visible (Yuujinchou.Language.except c);
+              Scope.modify_export (Yuujinchou.Language.except c))
             names;
           Reporter.fatal_diagnostic d)
       @@ fun () ->
@@ -360,8 +361,8 @@ let execute : Command.t -> unit = function
       (* TODO: Should the "name" of a notation actually be a Constant.t, to be looked up in the scope? *)
       let _ = Scope.define notation_name in
       Reporter.try_with ~fatal:(fun d ->
-          Scope.S.modify_visible (Yuujinchou.Language.except notation_name);
-          Scope.S.modify_export (Yuujinchou.Language.except notation_name);
+          Scope.modify_visible (Yuujinchou.Language.except notation_name);
+          Scope.modify_export (Yuujinchou.Language.except notation_name);
           Reporter.fatal_diagnostic d)
       @@ fun () ->
       let head =

--- a/lib/parser/command.ml
+++ b/lib/parser/command.ml
@@ -50,7 +50,7 @@ module Command = struct
         args : (string * Whitespace.t list) list;
       }
         -> t
-    | Require of { wsreq : Whitespace.t list; file : string; wsfile : Whitespace.t list }
+    | Import of { wsimport : Whitespace.t list; file : string; wsfile : Whitespace.t list }
     | Quit of Whitespace.t list
     | Bof of Whitespace.t list
     | Eof
@@ -214,11 +214,11 @@ module Parse = struct
            args;
          })
 
-  let require =
-    let* wsreq = token Require in
+  let import =
+    let* wsimport = token Import in
     step "" (fun state _ (tok, wsfile) ->
         match tok with
-        | String file -> Some (Require { wsreq; file; wsfile }, state)
+        | String file -> Some (Import { wsimport; file; wsfile }, state)
         | _ -> None)
 
   let quit =
@@ -233,7 +233,7 @@ module Parse = struct
     let* () = expect_end () in
     return Command.Eof
 
-  let command () = bof </> axiom </> def_and </> echo </> notation </> require </> quit </> eof
+  let command () = bof </> axiom </> def_and </> echo </> notation </> import </> quit </> eof
 
   let command_or_echo () =
     command ()
@@ -407,7 +407,7 @@ let execute : Command.t -> unit = function
            | `Constant c -> String.concat "." (Scope.name_of c) in
          emit (Head_already_has_notation keyname));
       emit (Notation_defined (String.concat "." name))
-  | Require { file; _ } ->
+  | Import { file; _ } ->
       let trie = Units.get (`File file) false in
       Scope.import_subtree ([], trie)
   | Quit _ -> fatal Quit
@@ -569,10 +569,10 @@ let pp_command : formatter -> t -> Whitespace.t list =
             rest in
       pp_close_box ppf ();
       rest
-  | Require { wsreq; file; wsfile } ->
+  | Import { wsimport; file; wsfile } ->
       pp_open_hvbox ppf 2;
-      pp_tok ppf Require;
-      pp_ws `Nobreak ppf wsreq;
+      pp_tok ppf Import;
+      pp_ws `Nobreak ppf wsimport;
       pp_print_string ppf "\"";
       pp_print_string ppf file;
       pp_print_string ppf "\"";

--- a/lib/parser/command.ml
+++ b/lib/parser/command.ml
@@ -408,6 +408,8 @@ let execute : Command.t -> unit = function
          emit (Head_already_has_notation keyname));
       emit (Notation_defined (String.concat "." name))
   | Import { file; _ } ->
+      if FilePath.check_extension file "ny" then emit (Library_has_extension file);
+      let file = FilePath.add_extension file "ny" in
       let trie = Units.get (`File file) false in
       Scope.import_subtree ([], trie)
   | Quit _ -> fatal Quit

--- a/lib/parser/command.ml
+++ b/lib/parser/command.ml
@@ -402,7 +402,7 @@ let execute : Command.t -> unit = function
       Scope.include_singleton (notation_name, (`Notation n, ()));
       emit (Notation_defined (String.concat "." name))
   | Require { file; _ } ->
-      let trie = Scope.get_unit (`File file) false in
+      let trie = Units.get (`File file) false in
       Scope.import_subtree ([], trie)
   | Quit _ -> fatal Quit
   | Bof _ -> ()

--- a/lib/parser/dune
+++ b/lib/parser/dune
@@ -1,5 +1,5 @@
 (library
   (name parser)
-  (libraries util bwd algaeff core fmlib_parse uuseg zarith yuujinchou)
+  (libraries util bwd algaeff core fmlib_parse uuseg zarith yuujinchou fileutils)
 	(instrumentation (backend landmarks --auto)))
 (env (_ (flags (:standard -w -69))))

--- a/lib/parser/lexer.ml
+++ b/lib/parser/lexer.ml
@@ -200,7 +200,7 @@ let canonicalize (rng : Position.range) : string -> Token.t t = function
   | "data" -> return Data
   | "codata" -> return Codata
   | "notation" -> return Notation
-  | "require" -> return Require
+  | "import" -> return Import
   | "." -> return Dot
   | "..." -> return Ellipsis
   | "_" -> return Underscore

--- a/lib/parser/lexer.ml
+++ b/lib/parser/lexer.ml
@@ -200,6 +200,7 @@ let canonicalize (rng : Position.range) : string -> Token.t t = function
   | "data" -> return Data
   | "codata" -> return Codata
   | "notation" -> return Notation
+  | "require" -> return Require
   | "." -> return Dot
   | "..." -> return Ellipsis
   | "_" -> return Underscore

--- a/lib/parser/pi.ml
+++ b/lib/parser/pi.ml
@@ -23,4 +23,4 @@ let install trie =
   let rtm = process Emp ptm in
   let ctm = check (Potential (Constant const, Ctx.apps ctx, Ctx.lam ctx)) ctx rtm ety in
   Global.add const cty (Defined ctm);
-  Scope.M.union_singleton ~prefix:Emp trie ([ "Π" ], const)
+  Scope.M.union_singleton ~prefix:Emp trie ([ "Π" ], `Constant const)

--- a/lib/parser/pi.ml
+++ b/lib/parser/pi.ml
@@ -7,23 +7,20 @@ open Notation
 open Postprocess
 
 let const = Constant.make ()
-let installed = ref false
 
-let install () =
-  if not !installed then (
-    installed := true;
-    let ctx = Ctx.empty in
-    let (Term pty) =
-      Parse.Term.final
-        (Parse.Term.parse
-           (`String { content = "(A : Type) (B : A -> Type) -> Type"; title = None })) in
-    let rty = process Emp pty in
-    let cty = check (Kinetic `Nolet) ctx rty (universe D.zero) in
-    let ety = eval_term (Ctx.env ctx) cty in
-    let (Term ptm) =
-      Parse.Term.final
-        (Parse.Term.parse (`String { content = "A B |-> (x : A) -> B x"; title = None })) in
-    let rtm = process Emp ptm in
-    let ctm = check (Potential (Constant const, Ctx.apps ctx, Ctx.lam ctx)) ctx rtm ety in
-    Global.add const cty (Defined ctm);
-    Scope.set [ "Π" ] const)
+let install trie =
+  let ctx = Ctx.empty in
+  let (Term pty) =
+    Parse.Term.final
+      (Parse.Term.parse (`String { content = "(A : Type) (B : A -> Type) -> Type"; title = None }))
+  in
+  let rty = process Emp pty in
+  let cty = check (Kinetic `Nolet) ctx rty (universe D.zero) in
+  let ety = eval_term (Ctx.env ctx) cty in
+  let (Term ptm) =
+    Parse.Term.final
+      (Parse.Term.parse (`String { content = "A B |-> (x : A) -> B x"; title = None })) in
+  let rtm = process Emp ptm in
+  let ctm = check (Potential (Constant const, Ctx.apps ctx, Ctx.lam ctx)) ctx rtm ety in
+  Global.add const cty (Defined ctm);
+  Scope.M.union_singleton ~prefix:Emp trie ([ "Π" ], const)

--- a/lib/parser/scope.ml
+++ b/lib/parser/scope.ml
@@ -1,33 +1,51 @@
 open Core
-include Yuujinchou
+module Trie = Yuujinchou.Trie
 
-let find_data trie x =
-  Seq.find_map (fun (path, (data, _)) -> if data = x then Some path else None) (Trie.to_seq trie)
-
+(* Parameter module for Yuujinchou *)
 module P = struct
   type data = Constant.t
+
+  (* Currently we have no nontrivial tags, hooks, or contexts. *)
   type tag = unit
   type hook = unit
   type context = unit
 end
 
-module S = Scope.Make (P)
+(* Modifier module for Yuujinchou *)
+module M = struct
+  include Yuujinchou.Modifier.Make (P)
 
-let lookup name = Option.map fst (S.resolve name)
+  (* We wrap the 'union' operations of Yuujinchou.Trie so that they merge by performing the modifier shadow effect, just as Scope does. *)
+  let union ~prefix ?context_export t1 t2 = Trie.union ~prefix (Perform.shadow context_export) t1 t2
+
+  let union_subtree ~prefix ?context_export t1 pt2 =
+    Trie.union_subtree ~prefix (Perform.shadow context_export) t1 pt2
+
+  let union_singleton ~prefix ?context_export t1 (path, const) =
+    Trie.union_singleton ~prefix (Perform.shadow context_export) t1 (path, (const, ()))
+
+  let union_root ~prefix ?context_export t r =
+    Trie.union_root ~prefix (Perform.shadow context_export) t r
+end
+
+(* The Yuujinchou Scope instance, that manages a pair of import/export scopes with effects. *)
+include Yuujinchou.Scope.Make (P)
+
+(* Look up a name to get a constant. *)
+let lookup name = Option.map fst (resolve name)
+
+(* Backwards lookup of a constant to find its name. *)
+let find_data trie x =
+  Seq.find_map (fun (path, (data, _)) -> if data = x then Some path else None) (Trie.to_seq trie)
 
 let name_of c =
-  match find_data (S.get_visible ()) c with
+  match find_data (get_visible ()) c with
   | Some name -> name
   (* TODO: Better to munge the original name. *)
   | None -> [ "_UNNAMED_CONSTANT" ]
 
-(* If we already have a Constant.t, set a name to refer to that constant.  (Used for whitebox testing.) *)
-let set name c = S.include_singleton (name, (c, ()))
-
 (* Create a new Constant.t and define a name to equal it. *)
 let define name =
   let c = Constant.make () in
-  set name c;
+  include_singleton (name, (c, ()));
   c
-
-let run = S.run

--- a/lib/parser/scope.ml
+++ b/lib/parser/scope.ml
@@ -1,4 +1,6 @@
+open Bwd
 open Core
+open Reporter
 module Trie = Yuujinchou.Trie
 
 (* Parameter module for Yuujinchou *)
@@ -10,6 +12,8 @@ module P = struct
   type hook = unit
   type context = unit
 end
+
+type trie = (P.data, P.tag) Trie.t
 
 (* Modifier module for Yuujinchou *)
 module M = struct
@@ -49,3 +53,86 @@ let define name =
   let c = Constant.make () in
   include_singleton (name, (c, ()));
   c
+
+(* For separate compilation, we expect the executable to know how to load compilation units and compute their resulting export namespaces.  We wrap this in an effect, so that it can also be invoked *during* the loading of some other unit, with a 'require' command.  We also include an effect that combines all the top-level namespaces (i.e. those not only loaded "transitively" through require) so far into a single one.  The boolean argument to load_unit indicates whether it is being invoked from top level, and the namespace is a starting visible one to override the default.  *)
+
+type _ Effect.t +=
+  | Load_unit : Asai.Range.source * trie option * bool -> trie Effect.t
+  | All_units : (P.data, P.tag) Trie.t Effect.t
+
+let get_unit ?init source top = Effect.perform (Load_unit (source, init, top))
+
+(* This is the version that is called *by* the executable, since it doesn't have any use for the resulting namespace, and it is always loading at top-level. *)
+let load_unit ?init source =
+  let _ = get_unit ?init source true in
+  ()
+
+let all_units () = Effect.perform All_units
+
+module Loadstate = struct
+  type t = { cwd : FilePath.filename; parents : FilePath.filename Bwd.t }
+end
+
+module Loading = Algaeff.Reader.Make (Loadstate)
+
+(* This is how the executable supplies a callback that loads files.  We take care of calling that function as needed and caching the results in a hashtable for future calls.  We also compute the result of combining all the units, but lazily since we'll only need it if there are command-line strings, stdin, or interactive.  The first argument is a default initial visible namespace, which can be overridden. *)
+let with_units : type a. trie -> (trie -> Asai.Range.source -> trie) -> (unit -> a) -> a =
+ fun init compute f ->
+  let table : (FilePath.filename, trie * bool) Hashtbl.t = Hashtbl.create 20 in
+  let all : (P.data, P.tag) Trie.t Lazy.t ref = ref (Lazy.from_val Trie.empty) in
+  let add_to_all trie =
+    let old = !all in
+    all := lazy (M.union ~prefix:Emp (Lazy.force old) trie) in
+  (* We use an inner recursive function so that we can re-wrap calls to "compute" in the same effect handler. *)
+  let rec go : type a. (unit -> a) -> a =
+   fun f ->
+    let open Effect.Deep in
+    try_with f ()
+      {
+        effc =
+          (fun (type a) (eff : a Effect.t) ->
+            match eff with
+            | Load_unit (source, start, top) -> (
+                let start = Option.value start ~default:init in
+                Option.some @@ fun (k : (a, _) continuation) ->
+                match source with
+                | `File file -> (
+                    (* We normalize the file path to a reduced absolute one, so we can use it for a hashtable key. *)
+                    let file =
+                      if FilePath.is_relative file then
+                        FilePath.make_absolute (Loading.read ()).cwd file
+                      else file in
+                    let file = FilePath.reduce file in
+                    match Hashtbl.find_opt table file with
+                    | Some (trie, top') ->
+                        (* If we already loaded that file, we just return its saved export namespace, but we may need to add it to the 'all' namespace if it wasn't already there. *)
+                        if top && not top' then (
+                          add_to_all trie;
+                          Hashtbl.add table file (trie, true));
+                        continue k trie
+                    | None ->
+                        (* Otherwise, we have to load it.  First we check for circular dependencies. *)
+                        (let parents = (Loading.read ()).parents in
+                         if Bwd.exists (fun x -> x = file) parents then
+                           fatal (Circular_dependency (Bwd.to_list (Snoc (parents, file)))));
+                        (* Then we load it, in its directory and with itself added to the list of parents, and then add it to the table and (possibly) 'all'. *)
+                        if not top then emit (Loading_file file);
+                        let trie =
+                          Loading.scope (fun s ->
+                              { cwd = FilePath.dirname file; parents = Snoc (s.parents, file) })
+                          @@ fun () ->
+                          go @@ fun () -> compute start source in
+                        if not top then emit (File_loaded file);
+                        Hashtbl.add table file (trie, top);
+                        if top then add_to_all trie;
+                        continue k trie)
+                | `String _ ->
+                    (* In the case of a string input there is no caching and no change of state, since it can't be "required" from another file.  But we still have the option of adding it to "all".  *)
+                    let trie = go @@ fun () -> compute start source in
+                    if top then add_to_all trie;
+                    continue k trie)
+            | All_units ->
+                Option.some @@ fun (k : (a, _) continuation) -> continue k (Lazy.force !all)
+            | _ -> None);
+      } in
+  Loading.run ~env:{ cwd = Sys.getcwd (); parents = Emp } @@ fun () -> go f

--- a/lib/parser/scope.ml
+++ b/lib/parser/scope.ml
@@ -1,10 +1,10 @@
 open Core
-open Notation
+open User
 module Trie = Yuujinchou.Trie
 
 (* Parameter module for Yuujinchou *)
 module P = struct
-  type data = [ `Constant of Constant.t | `Notation of Notation.t ]
+  type data = [ `Constant of Constant.t | `Notation of PrintKey.t * permuted_notation ]
 
   (* Currently we have no nontrivial tags, hooks, or contexts. *)
   type tag = unit

--- a/lib/parser/scope.ml
+++ b/lib/parser/scope.ml
@@ -1,6 +1,4 @@
-open Bwd
 open Core
-open Reporter
 open Notation
 module Trie = Yuujinchou.Trie
 
@@ -13,8 +11,6 @@ module P = struct
   type hook = unit
   type context = unit
 end
-
-type trie = (P.data, P.tag) Trie.t
 
 (* Modifier module for Yuujinchou *)
 module M = struct
@@ -58,86 +54,3 @@ let define name =
   let c = Constant.make () in
   include_singleton (name, (`Constant c, ()));
   c
-
-(* For separate compilation, we expect the executable to know how to load compilation units and compute their resulting export namespaces.  We wrap this in an effect, so that it can also be invoked *during* the loading of some other unit, with a 'require' command.  We also include an effect that combines all the top-level namespaces (i.e. those not only loaded "transitively" through require) so far into a single one.  The boolean argument to load_unit indicates whether it is being invoked from top level, and the namespace is a starting visible one to override the default.  *)
-
-type _ Effect.t +=
-  | Load_unit : Asai.Range.source * trie option * bool -> trie Effect.t
-  | All_units : (P.data, P.tag) Trie.t Effect.t
-
-let get_unit ?init source top = Effect.perform (Load_unit (source, init, top))
-
-(* This is the version that is called *by* the executable, since it doesn't have any use for the resulting namespace, and it is always loading at top-level. *)
-let load_unit ?init source =
-  let _ = get_unit ?init source true in
-  ()
-
-let all_units () = Effect.perform All_units
-
-module Loadstate = struct
-  type t = { cwd : FilePath.filename; parents : FilePath.filename Bwd.t }
-end
-
-module Loading = Algaeff.Reader.Make (Loadstate)
-
-(* This is how the executable supplies a callback that loads files.  We take care of calling that function as needed and caching the results in a hashtable for future calls.  We also compute the result of combining all the units, but lazily since we'll only need it if there are command-line strings, stdin, or interactive.  The first argument is a default initial visible namespace, which can be overridden. *)
-let with_units : type a. trie -> (trie -> Asai.Range.source -> trie) -> (unit -> a) -> a =
- fun init compute f ->
-  let table : (FilePath.filename, trie * bool) Hashtbl.t = Hashtbl.create 20 in
-  let all : (P.data, P.tag) Trie.t Lazy.t ref = ref (Lazy.from_val Trie.empty) in
-  let add_to_all trie =
-    let old = !all in
-    all := lazy (M.union ~prefix:Emp (Lazy.force old) trie) in
-  (* We use an inner recursive function so that we can re-wrap calls to "compute" in the same effect handler. *)
-  let rec go : type a. (unit -> a) -> a =
-   fun f ->
-    let open Effect.Deep in
-    try_with f ()
-      {
-        effc =
-          (fun (type a) (eff : a Effect.t) ->
-            match eff with
-            | Load_unit (source, start, top) -> (
-                let start = Option.value start ~default:init in
-                Option.some @@ fun (k : (a, _) continuation) ->
-                match source with
-                | `File file -> (
-                    (* We normalize the file path to a reduced absolute one, so we can use it for a hashtable key. *)
-                    let file =
-                      if FilePath.is_relative file then
-                        FilePath.make_absolute (Loading.read ()).cwd file
-                      else file in
-                    let file = FilePath.reduce file in
-                    match Hashtbl.find_opt table file with
-                    | Some (trie, top') ->
-                        (* If we already loaded that file, we just return its saved export namespace, but we may need to add it to the 'all' namespace if it wasn't already there. *)
-                        if top && not top' then (
-                          add_to_all trie;
-                          Hashtbl.add table file (trie, true));
-                        continue k trie
-                    | None ->
-                        (* Otherwise, we have to load it.  First we check for circular dependencies. *)
-                        (let parents = (Loading.read ()).parents in
-                         if Bwd.exists (fun x -> x = file) parents then
-                           fatal (Circular_dependency (Bwd.to_list (Snoc (parents, file)))));
-                        (* Then we load it, in its directory and with itself added to the list of parents, and then add it to the table and (possibly) 'all'. *)
-                        if not top then emit (Loading_file file);
-                        let trie =
-                          Loading.scope (fun s ->
-                              { cwd = FilePath.dirname file; parents = Snoc (s.parents, file) })
-                          @@ fun () ->
-                          go @@ fun () -> compute start source in
-                        if not top then emit (File_loaded file);
-                        Hashtbl.add table file (trie, top);
-                        if top then add_to_all trie;
-                        continue k trie)
-                | `String _ ->
-                    (* In the case of a string input there is no caching and no change of state, since it can't be "required" from another file.  But we still have the option of adding it to "all".  *)
-                    let trie = go @@ fun () -> compute start source in
-                    if top then add_to_all trie;
-                    continue k trie)
-            | All_units ->
-                Option.some @@ fun (k : (a, _) continuation) -> continue k (Lazy.force !all)
-            | _ -> None);
-      } in
-  Loading.run ~env:{ cwd = Sys.getcwd (); parents = Emp } @@ fun () -> go f

--- a/lib/parser/token.ml
+++ b/lib/parser/token.ml
@@ -36,7 +36,7 @@ type t =
   | Data
   | Codata
   | Notation
-  | Require
+  | Import
   | Let
   | In
   | Op of string (* Sequence of common ASCII symbols, other than : := ::= += -> |-> |=> etc. *)
@@ -169,7 +169,7 @@ let to_string = function
   | Data -> "data"
   | Codata -> "codata"
   | Notation -> "notation"
-  | Require -> "require"
+  | Import -> "import"
   | Let -> "let"
   | In -> "in"
   | Op s -> s

--- a/lib/parser/token.ml
+++ b/lib/parser/token.ml
@@ -36,6 +36,7 @@ type t =
   | Data
   | Codata
   | Notation
+  | Require
   | Let
   | In
   | Op of string (* Sequence of common ASCII symbols, other than : := ::= += -> |-> |=> etc. *)
@@ -168,6 +169,7 @@ let to_string = function
   | Data -> "data"
   | Codata -> "codata"
   | Notation -> "notation"
+  | Require -> "require"
   | Let -> "let"
   | In -> "in"
   | Op s -> s

--- a/lib/parser/units.ml
+++ b/lib/parser/units.ml
@@ -65,7 +65,7 @@ let with_compile : type a. trie -> (trie -> Asai.Range.source -> trie) -> (unit 
                         (* Otherwise, we have to load it.  First we check for circular dependencies. *)
                         (let parents = (Loading.read ()).parents in
                          if Bwd.exists (fun x -> x = file) parents then
-                           fatal (Circular_dependency (Bwd.to_list (Snoc (parents, file)))));
+                           fatal (Circular_import (Bwd.to_list (Snoc (parents, file)))));
                         (* Then we load it, in its directory and with itself added to the list of parents, and then add it to the table and (possibly) 'all'. *)
                         if not top then emit (Loading_file file);
                         let trie =

--- a/lib/parser/units.ml
+++ b/lib/parser/units.ml
@@ -1,0 +1,91 @@
+open Bwd
+open Core
+open Reporter
+module Trie = Yuujinchou.Trie
+
+type trie = (Scope.P.data, Scope.P.tag) Trie.t
+
+(* For separate compilation, we expect the executable to know how to load compilation units and compute their resulting export namespaces.  We wrap this in an effect, so that it can also be invoked *during* the loading of some other unit, with a 'require' command.  We also include an effect that combines all the top-level namespaces (i.e. those not only loaded "transitively" through require) so far into a single one.  The boolean argument to load_unit indicates whether it is being invoked from top level, and the namespace is a starting visible one to override the default.  *)
+
+type _ Effect.t +=
+  | Load_unit : Asai.Range.source * trie option * bool -> trie Effect.t
+  | All_units : trie Effect.t
+
+let get ?init source top = Effect.perform (Load_unit (source, init, top))
+
+(* This is the version that is called *by* the executable, since it doesn't have any use for the resulting namespace, and it is always loading at top-level. *)
+let load ?init source =
+  let _ = get ?init source true in
+  ()
+
+let all () = Effect.perform All_units
+
+module Loadstate = struct
+  type t = { cwd : FilePath.filename; parents : FilePath.filename Bwd.t }
+end
+
+module Loading = Algaeff.Reader.Make (Loadstate)
+
+(* This is how the executable supplies a callback that loads files.  We take care of calling that function as needed and caching the results in a hashtable for future calls.  We also compute the result of combining all the units, but lazily since we'll only need it if there are command-line strings, stdin, or interactive.  The first argument is a default initial visible namespace, which can be overridden. *)
+let with_compile : type a. trie -> (trie -> Asai.Range.source -> trie) -> (unit -> a) -> a =
+ fun init compute f ->
+  let table : (FilePath.filename, trie * bool) Hashtbl.t = Hashtbl.create 20 in
+  let all : trie Lazy.t ref = ref (Lazy.from_val Trie.empty) in
+  let add_to_all trie =
+    let old = !all in
+    all := lazy (Scope.M.union ~prefix:Emp (Lazy.force old) trie) in
+  (* We use an inner recursive function so that we can re-wrap calls to "compute" in the same effect handler. *)
+  let rec go : type a. (unit -> a) -> a =
+   fun f ->
+    let open Effect.Deep in
+    try_with f ()
+      {
+        effc =
+          (fun (type a) (eff : a Effect.t) ->
+            match eff with
+            | Load_unit (source, start, top) -> (
+                let start = Option.value start ~default:init in
+                Option.some @@ fun (k : (a, _) continuation) ->
+                match source with
+                | `File file -> (
+                    (* We normalize the file path to a reduced absolute one, so we can use it for a hashtable key. *)
+                    let file =
+                      if FilePath.is_relative file then
+                        FilePath.make_absolute (Loading.read ()).cwd file
+                      else file in
+                    let file = FilePath.reduce file in
+                    match Hashtbl.find_opt table file with
+                    | Some (trie, top') ->
+                        (* If we already loaded that file, we just return its saved export namespace, but we may need to add it to the 'all' namespace if it wasn't already there. *)
+                        if top && not top' then (
+                          add_to_all trie;
+                          Hashtbl.add table file (trie, true));
+                        continue k trie
+                    | None ->
+                        (* Otherwise, we have to load it.  First we check for circular dependencies. *)
+                        (let parents = (Loading.read ()).parents in
+                         if Bwd.exists (fun x -> x = file) parents then
+                           fatal (Circular_dependency (Bwd.to_list (Snoc (parents, file)))));
+                        (* Then we load it, in its directory and with itself added to the list of parents, and then add it to the table and (possibly) 'all'. *)
+                        if not top then emit (Loading_file file);
+                        let trie =
+                          Loading.scope (fun s ->
+                              { cwd = FilePath.dirname file; parents = Snoc (s.parents, file) })
+                          @@ fun () ->
+                          go @@ fun () -> compute start source in
+                        if not top then emit (File_loaded file);
+                        Hashtbl.add table file (trie, top);
+                        if top then add_to_all trie;
+                        continue k trie)
+                | `String _ ->
+                    (* In the case of a string input there is no caching and no change of state, since it can't be "required" from another file.  But we still have the option of adding it to "all".  *)
+                    let trie = go @@ fun () -> compute start source in
+                    if top then add_to_all trie;
+                    continue k trie)
+            | All_units ->
+                Option.some @@ fun (k : (a, _) continuation) -> continue k (Lazy.force !all)
+            | _ -> None);
+      } in
+  Loading.run ~env:{ cwd = Sys.getcwd (); parents = Emp } @@ fun () -> go f
+
+let run ~init_visible f = Scope.run ~init_visible f

--- a/lib/parser/user.ml
+++ b/lib/parser/user.ml
@@ -1,0 +1,13 @@
+open Notation
+
+(* User notations *)
+
+module PrintKey = struct
+  type t = [ `Constant of Core.Constant.t | `Constr of Core.Constr.t * int ]
+
+  let compare : t -> t -> int = compare
+end
+
+module PrintMap = Map.Make (PrintKey)
+
+type permuted_notation = { notn : Notation.t; pat_vars : string list; val_vars : string list }

--- a/test/black/axiomK.t
+++ b/test/black/axiomK.t
@@ -62,6 +62,7 @@ This "weak K" is mentioned in the "Pattern-matching without K" paper as justifyi
 The following indexed datatype appears in Agda bug #1025.
 
   $ cat >foo.ny <<EOF
+  > require "jd.ny"
   > axiom A : Type
   > axiom a : A
   > def Foo : Jd A a a → Type ≔ data [ foo. : Foo rfl. ]

--- a/test/black/axiomK.t
+++ b/test/black/axiomK.t
@@ -62,7 +62,7 @@ This "weak K" is mentioned in the "Pattern-matching without K" paper as justifyi
 The following indexed datatype appears in Agda bug #1025.
 
   $ cat >foo.ny <<EOF
-  > import "jd.ny"
+  > import "jd"
   > axiom A : Type
   > axiom a : A
   > def Foo : Jd A a a → Type ≔ data [ foo. : Foo rfl. ]

--- a/test/black/axiomK.t
+++ b/test/black/axiomK.t
@@ -62,7 +62,7 @@ This "weak K" is mentioned in the "Pattern-matching without K" paper as justifyi
 The following indexed datatype appears in Agda bug #1025.
 
   $ cat >foo.ny <<EOF
-  > require "jd.ny"
+  > import "jd.ny"
   > axiom A : Type
   > axiom a : A
   > def Foo : Jd A a a → Type ≔ data [ foo. : Foo rfl. ]

--- a/test/black/discreteness.t
+++ b/test/black/discreteness.t
@@ -1,8 +1,5 @@
-  $ cat >isprop.ny <<EOF
-  > axiom t1 : T
-  > axiom t2 : T
+  $ cat >jd.ny <<EOF
   > def Jd (X:Type) (x:X) : X → Type ≔ data [ rfl. : Jd X x x ]
-  > def test : Jd T t1 t2 ≔ rfl.
   > EOF
 
 Arbitrary types are not discrete:
@@ -13,10 +10,10 @@ Arbitrary types are not discrete:
   > def T ≔ A⁽ᵈ⁾ a
   > EOF
 
-  $ narya -arity 1 -direction d arb.ny isprop.ny
+  $ narya -arity 1 -direction d arb.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
    ￫ error[E1003]
-   ￭ isprop.ny
-   4 | def test : Jd T t1 t2 ≔ rfl.
+   ￭ command-line exec string
+   1 | def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.
      ^ index
          t1
        of constructor application doesn't match the corresponding index
@@ -27,10 +24,10 @@ Arbitrary types are not discrete:
 
 They remain so even when discreteness is on:
 
-  $ narya -arity 1 -direction d -discreteness arb.ny isprop.ny
+  $ narya -arity 1 -direction d -discreteness arb.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
    ￫ error[E1003]
-   ￭ isprop.ny
-   4 | def test : Jd T t1 t2 ≔ rfl.
+   ￭ command-line exec string
+   1 | def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.
      ^ index
          t1
        of constructor application doesn't match the corresponding index
@@ -47,7 +44,7 @@ There are no discrete datatypes if discreteness is off:
   > def T ≔ ℕ⁽ᵈ⁾ n
   > EOF
 
-  $ narya -v -arity 1 -direction d natd.ny isprop.ny
+  $ narya -v -arity 1 -direction d natd.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
    ￫ info[I0000]
    ￮ Constant ℕ defined
   
@@ -57,18 +54,12 @@ There are no discrete datatypes if discreteness is off:
    ￫ info[I0000]
    ￮ Constant T defined
   
-   ￫ info[I0001]
-   ￮ Axiom t1 assumed
-  
-   ￫ info[I0001]
-   ￮ Axiom t2 assumed
-  
    ￫ info[I0000]
    ￮ Constant Jd defined
   
    ￫ error[E1003]
-   ￭ isprop.ny
-   4 | def test : Jd T t1 t2 ≔ rfl.
+   ￭ command-line exec string
+   1 | def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.
      ^ index
          t1
        of constructor application doesn't match the corresponding index
@@ -83,22 +74,16 @@ Discrete datatypes are not themselves propositions:
   > def T : Type ≔ data [ zero. | suc. (_:T) ]
   > EOF
 
-  $ narya -v -arity 1 -direction d -discreteness nat.ny isprop.ny
+  $ narya -v -arity 1 -direction d -discreteness nat.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
    ￫ info[I0000]
    ￮ Constant T defined (discrete)
-  
-   ￫ info[I0001]
-   ￮ Axiom t1 assumed
-  
-   ￫ info[I0001]
-   ￮ Axiom t2 assumed
   
    ￫ info[I0000]
    ￮ Constant Jd defined
   
    ￫ error[E1003]
-   ￭ isprop.ny
-   4 | def test : Jd T t1 t2 ≔ rfl.
+   ￭ command-line exec string
+   1 | def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.
      ^ index
          t1
        of constructor application doesn't match the corresponding index
@@ -115,7 +100,7 @@ But their degenerate versions are:
   > def T ≔ ℕ⁽ᵈ⁾ n
   > EOF
 
-  $ narya -v -arity 1 -direction d -discreteness natd.ny isprop.ny
+  $ narya -v -arity 1 -direction d -discreteness natd.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
    ￫ info[I0000]
    ￮ Constant ℕ defined (discrete)
   
@@ -124,12 +109,6 @@ But their degenerate versions are:
   
    ￫ info[I0000]
    ￮ Constant T defined
-  
-   ￫ info[I0001]
-   ￮ Axiom t1 assumed
-  
-   ￫ info[I0001]
-   ￮ Axiom t2 assumed
   
    ￫ info[I0000]
    ￮ Constant Jd defined
@@ -146,7 +125,7 @@ Non-discrete datatypes are not discrete:
   > axiom l : List A
   > def T ≔ (List A)⁽ᵈ⁾ l
 
-  $ narya -v -arity 1 -direction d -discreteness param.ny isprop.ny
+  $ narya -v -arity 1 -direction d -discreteness param.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
    ￫ info[I0000]
    ￮ Constant List defined
   
@@ -159,18 +138,12 @@ Non-discrete datatypes are not discrete:
    ￫ info[I0000]
    ￮ Constant T defined
   
-   ￫ info[I0001]
-   ￮ Axiom t1 assumed
-  
-   ￫ info[I0001]
-   ￮ Axiom t2 assumed
-  
    ￫ info[I0000]
    ￮ Constant Jd defined
   
    ￫ error[E1003]
-   ￭ isprop.ny
-   4 | def test : Jd T t1 t2 ≔ rfl.
+   ￭ command-line exec string
+   1 | def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.
      ^ index
          t1
        of constructor application doesn't match the corresponding index
@@ -186,7 +159,7 @@ Non-discrete datatypes are not discrete:
   > axiom z : iszero n
   > def T ≔ (iszero n)⁽ᵈ⁾ z
 
-  $ narya -v -arity 1 -direction d -discreteness index.ny isprop.ny
+  $ narya -v -arity 1 -direction d -discreteness index.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
    ￫ info[I0000]
    ￮ Constant ℕ defined (discrete)
   
@@ -202,18 +175,12 @@ Non-discrete datatypes are not discrete:
    ￫ info[I0000]
    ￮ Constant T defined
   
-   ￫ info[I0001]
-   ￮ Axiom t1 assumed
-  
-   ￫ info[I0001]
-   ￮ Axiom t2 assumed
-  
    ￫ info[I0000]
    ￮ Constant Jd defined
   
    ￫ error[E1003]
-   ￭ isprop.ny
-   4 | def test : Jd T t1 t2 ≔ rfl.
+   ￭ command-line exec string
+   1 | def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.
      ^ index
          t1
        of constructor application doesn't match the corresponding index
@@ -227,7 +194,7 @@ Non-discrete datatypes are not discrete:
   > axiom f : foo
   > def T ≔ foo⁽ᵈ⁾ f
 
-  $ narya -v -arity 1 -direction d -discreteness constr.ny isprop.ny
+  $ narya -v -arity 1 -direction d -discreteness constr.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
    ￫ info[I0000]
    ￮ Constant foo defined
   
@@ -237,18 +204,12 @@ Non-discrete datatypes are not discrete:
    ￫ info[I0000]
    ￮ Constant T defined
   
-   ￫ info[I0001]
-   ￮ Axiom t1 assumed
-  
-   ￫ info[I0001]
-   ￮ Axiom t2 assumed
-  
    ￫ info[I0000]
    ￮ Constant Jd defined
   
    ￫ error[E1003]
-   ￭ isprop.ny
-   4 | def test : Jd T t1 t2 ≔ rfl.
+   ￭ command-line exec string
+   1 | def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.
      ^ index
          t1
        of constructor application doesn't match the corresponding index
@@ -264,7 +225,7 @@ Non-discrete datatypes are not discrete:
   > def T ≔ even⁽ᵈ⁾ e
   > EOF
 
-  $ narya -v -arity 1 -direction d -discreteness mutual.ny isprop.ny
+  $ narya -v -arity 1 -direction d -discreteness mutual.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
    ￫ info[I0000]
    ￮ Constants defined mutually:
        even
@@ -276,18 +237,12 @@ Non-discrete datatypes are not discrete:
    ￫ info[I0000]
    ￮ Constant T defined
   
-   ￫ info[I0001]
-   ￮ Axiom t1 assumed
-  
-   ￫ info[I0001]
-   ￮ Axiom t2 assumed
-  
    ￫ info[I0000]
    ￮ Constant Jd defined
   
    ￫ error[E1003]
-   ￭ isprop.ny
-   4 | def test : Jd T t1 t2 ≔ rfl.
+   ￭ command-line exec string
+   1 | def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.
      ^ index
          t1
        of constructor application doesn't match the corresponding index

--- a/test/black/dtt.t/run.t
+++ b/test/black/dtt.t/run.t
@@ -172,6 +172,6 @@
 
   $ narya -dtt mutual.ny
    ￫ error[E3000]
-   ￮ There are open holes
+   ￮ there are open holes
   
   [1]

--- a/test/black/holes.t/run.t
+++ b/test/black/holes.t/run.t
@@ -341,7 +341,7 @@
    ￮ Constant idafam defined
   
    ￫ error[E3000]
-   ￮ There are open holes
+   ￮ there are open holes
   
   [1]
 

--- a/test/black/import.t
+++ b/test/black/import.t
@@ -1,11 +1,11 @@
-Require files
+Import files
 
   $ cat >one.ny <<EOF
   > axiom A : Type
   > EOF
 
   $ cat >two.ny <<EOF
-  > require "one.ny"
+  > import "one.ny"
   > axiom a0 : A
   > EOF
 
@@ -56,13 +56,13 @@ Command-line strings see namespaces from explicitly loaded files only
 Requiring a file multiple times
 
   $ cat >three.ny <<EOF
-  > require "one.ny"
+  > import "one.ny"
   > axiom a1 : A
   > EOF
 
   $ cat >twothree.ny <<EOF
-  > require "two.ny"
-  > require "three.ny"
+  > import "two.ny"
+  > import "three.ny"
   > axiom a2 : Id A a0 a1
 
   $ narya -v twothree.ny
@@ -101,9 +101,9 @@ Requiring a file multiple times
   [1]
 
   $ cat >four.ny <<EOF
-  > require "one.ny"
-  > require "two.ny"
-  > require "three.ny"
+  > import "one.ny"
+  > import "two.ny"
+  > import "three.ny"
   > axiom a2 : Id A a0 a1
 
   $ narya -v four.ny
@@ -141,23 +141,23 @@ Requiring a file multiple times
 Circular dependency
 
   $ cat >foo.ny <<EOF
-  > require "bar.ny"
+  > import "bar.ny"
   > EOF
 
   $ cat >bar.ny <<EOF
-  > require "foo.ny"
+  > import "foo.ny"
   > EOF
 
   $ narya foo.ny
    ￫ error[E2300]
-   ￮ circular dependency:
+   ￮ circular imports:
      $TESTCASE_ROOT/foo.ny
-       requires $TESTCASE_ROOT/bar.ny
-       requires $TESTCASE_ROOT/foo.ny
+       imports $TESTCASE_ROOT/bar.ny
+       imports $TESTCASE_ROOT/foo.ny
   
   [1]
 
-Require is relative to the file's directory
+Import is relative to the file's directory
 
   $ mkdir subdir
 
@@ -166,11 +166,11 @@ Require is relative to the file's directory
   > EOF
 
   $ cat >subdir/two.ny <<EOF
-  > require "one.ny"
+  > import "one.ny"
   > axiom a : A
   > EOF
 
-  $ narya -v -e 'require "subdir/two.ny"'
+  $ narya -v -e 'import "subdir/two.ny"'
    ￫ info[I0003]
    ￮ loading file: $TESTCASE_ROOT/subdir/two.ny
   
@@ -192,7 +192,7 @@ Require is relative to the file's directory
 
 A file isn't loaded twice even if referred to in different ways
 
-  $ narya -v subdir/one.ny -e 'require "subdir/two.ny"'
+  $ narya -v subdir/one.ny -e 'import "subdir/two.ny"'
    ￫ info[I0001]
    ￮ Axiom A assumed
   
@@ -206,7 +206,7 @@ A file isn't loaded twice even if referred to in different ways
    ￮ file loaded: $TESTCASE_ROOT/subdir/two.ny
   
 
-Notations are imported from explicitly required files, but not transitively.
+Notations are used from explicitly imported files, but not transitively.
 
   $ cat >n1.ny <<EOF
   > axiom A:Type
@@ -215,13 +215,13 @@ Notations are imported from explicitly required files, but not transitively.
   > EOF
 
   $ cat >n2.ny <<EOF
-  > require "n1.ny"
+  > import "n1.ny"
   > notation 0 f : x "&" y := f x y
   > EOF
 
   $ cat >n3.ny <<EOF
-  > require "n1.ny"
-  > require "n2.ny"
+  > import "n1.ny"
+  > import "n2.ny"
   > notation 0 f2 : x "%" y := f x y
   > EOF
 

--- a/test/black/import.t
+++ b/test/black/import.t
@@ -240,3 +240,33 @@ Notations are used from explicitly imported files, but not transitively.
      ^ parse error
   
   [1]
+
+Quitting in imports quits only that file
+
+  $ cat >qone.ny <<EOF
+  > axiom A : Type
+  > quit
+  > axiom B : Type
+  > EOF
+
+  $ cat >qtwo.ny <<EOF
+  > import "qone"
+  > axiom a0 : A
+  > EOF
+
+  $ narya -v qtwo.ny
+   ￫ info[I0003]
+   ￮ loading file: $TESTCASE_ROOT/qone.ny
+  
+   ￫ info[I0001]
+   ￮ Axiom A assumed
+  
+   ￫ info[I0200]
+   ￮ execution of qone.ny terminated by quit
+  
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/qone.ny
+  
+   ￫ info[I0001]
+   ￮ Axiom a0 assumed
+  

--- a/test/black/import.t
+++ b/test/black/import.t
@@ -5,7 +5,7 @@ Import files
   > EOF
 
   $ cat >two.ny <<EOF
-  > import "one.ny"
+  > import "one"
   > axiom a0 : A
   > EOF
 
@@ -56,13 +56,13 @@ Command-line strings see namespaces from explicitly loaded files only
 Requiring a file multiple times
 
   $ cat >three.ny <<EOF
-  > import "one.ny"
+  > import "one"
   > axiom a1 : A
   > EOF
 
   $ cat >twothree.ny <<EOF
-  > import "two.ny"
-  > import "three.ny"
+  > import "two"
+  > import "three"
   > axiom a2 : Id A a0 a1
 
   $ narya -v twothree.ny
@@ -101,9 +101,9 @@ Requiring a file multiple times
   [1]
 
   $ cat >four.ny <<EOF
-  > import "one.ny"
-  > import "two.ny"
-  > import "three.ny"
+  > import "one"
+  > import "two"
+  > import "three"
   > axiom a2 : Id A a0 a1
 
   $ narya -v four.ny
@@ -141,11 +141,11 @@ Requiring a file multiple times
 Circular dependency
 
   $ cat >foo.ny <<EOF
-  > import "bar.ny"
+  > import "bar"
   > EOF
 
   $ cat >bar.ny <<EOF
-  > import "foo.ny"
+  > import "foo"
   > EOF
 
   $ narya foo.ny
@@ -166,11 +166,11 @@ Import is relative to the file's directory
   > EOF
 
   $ cat >subdir/two.ny <<EOF
-  > import "one.ny"
+  > import "one"
   > axiom a : A
   > EOF
 
-  $ narya -v -e 'import "subdir/two.ny"'
+  $ narya -v -e 'import "subdir/two"'
    ￫ info[I0003]
    ￮ loading file: $TESTCASE_ROOT/subdir/two.ny
   
@@ -192,7 +192,7 @@ Import is relative to the file's directory
 
 A file isn't loaded twice even if referred to in different ways
 
-  $ narya -v subdir/one.ny -e 'import "subdir/two.ny"'
+  $ narya -v subdir/one.ny -e 'import "subdir/two"'
    ￫ info[I0001]
    ￮ Axiom A assumed
   
@@ -215,13 +215,13 @@ Notations are used from explicitly imported files, but not transitively.
   > EOF
 
   $ cat >n2.ny <<EOF
-  > import "n1.ny"
+  > import "n1"
   > notation 0 f : x "&" y := f x y
   > EOF
 
   $ cat >n3.ny <<EOF
-  > import "n1.ny"
-  > import "n2.ny"
+  > import "n1"
+  > import "n2"
   > notation 0 f2 : x "%" y := f x y
   > EOF
 

--- a/test/black/mutual.t/run.t
+++ b/test/black/mutual.t/run.t
@@ -116,10 +116,10 @@
        ty
   
    ￫ warning[E2100]
-   ￮ redefining constant: ctx
+   ￮ name already defined: ctx
   
    ￫ warning[E2100]
-   ￮ redefining constant: ty
+   ￮ name already defined: ty
   
    ￫ info[I0000]
    ￮ Constants defined mutually:

--- a/test/black/require.t
+++ b/test/black/require.t
@@ -1,0 +1,207 @@
+Require files
+
+  $ cat >one.ny <<EOF
+  > axiom A : Type
+  > EOF
+
+  $ cat >two.ny <<EOF
+  > require "one.ny"
+  > axiom a0 : A
+  > EOF
+
+  $ narya -v two.ny
+   ￫ info[I0003]
+   ￮ loading file: $TESTCASE_ROOT/one.ny
+  
+   ￫ info[I0001]
+   ￮ Axiom A assumed
+  
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/one.ny
+  
+   ￫ info[I0001]
+   ￮ Axiom a0 assumed
+  
+
+Command-line strings see namespaces from explicitly loaded files only
+
+  $ narya -v two.ny -e 'axiom a1 : A'
+   ￫ info[I0003]
+   ￮ loading file: $TESTCASE_ROOT/one.ny
+  
+   ￫ info[I0001]
+   ￮ Axiom A assumed
+  
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/one.ny
+  
+   ￫ info[I0001]
+   ￮ Axiom a0 assumed
+  
+   ￫ error[E0300]
+   ￭ command-line exec string
+   1 | axiom a1 : A
+     ^ unbound variable: A
+  
+  [1]
+
+  $ narya -v one.ny -e 'axiom a1 : A'
+   ￫ info[I0001]
+   ￮ Axiom A assumed
+  
+   ￫ info[I0001]
+   ￮ Axiom a1 assumed
+  
+
+Requiring a file multiple times
+
+  $ cat >three.ny <<EOF
+  > require "one.ny"
+  > axiom a1 : A
+  > EOF
+
+  $ cat >twothree.ny <<EOF
+  > require "two.ny"
+  > require "three.ny"
+  > axiom a2 : Id A a0 a1
+
+  $ narya -v twothree.ny
+   ￫ info[I0003]
+   ￮ loading file: $TESTCASE_ROOT/two.ny
+  
+   ￫ info[I0003]
+   ￮ loading file: $TESTCASE_ROOT/one.ny
+  
+   ￫ info[I0001]
+   ￮ Axiom A assumed
+  
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/one.ny
+  
+   ￫ info[I0001]
+   ￮ Axiom a0 assumed
+  
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/two.ny
+  
+   ￫ info[I0003]
+   ￮ loading file: $TESTCASE_ROOT/three.ny
+  
+   ￫ info[I0001]
+   ￮ Axiom a1 assumed
+  
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/three.ny
+  
+   ￫ error[E0300]
+   ￭ twothree.ny
+   3 | axiom a2 : Id A a0 a1
+     ^ unbound variable: A
+  
+  [1]
+
+  $ cat >four.ny <<EOF
+  > require "one.ny"
+  > require "two.ny"
+  > require "three.ny"
+  > axiom a2 : Id A a0 a1
+
+  $ narya -v four.ny
+   ￫ info[I0003]
+   ￮ loading file: $TESTCASE_ROOT/one.ny
+  
+   ￫ info[I0001]
+   ￮ Axiom A assumed
+  
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/one.ny
+  
+   ￫ info[I0003]
+   ￮ loading file: $TESTCASE_ROOT/two.ny
+  
+   ￫ info[I0001]
+   ￮ Axiom a0 assumed
+  
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/two.ny
+  
+   ￫ info[I0003]
+   ￮ loading file: $TESTCASE_ROOT/three.ny
+  
+   ￫ info[I0001]
+   ￮ Axiom a1 assumed
+  
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/three.ny
+  
+   ￫ info[I0001]
+   ￮ Axiom a2 assumed
+  
+
+Circular dependency
+
+  $ cat >foo.ny <<EOF
+  > require "bar.ny"
+  > EOF
+
+  $ cat >bar.ny <<EOF
+  > require "foo.ny"
+  > EOF
+
+  $ narya foo.ny
+   ￫ error[E2300]
+   ￮ circular dependency:
+     $TESTCASE_ROOT/foo.ny
+       requires $TESTCASE_ROOT/bar.ny
+       requires $TESTCASE_ROOT/foo.ny
+  
+  [1]
+
+Require is relative to the file's directory
+
+  $ mkdir subdir
+
+  $ cat >subdir/one.ny <<EOF
+  > axiom A:Type
+  > EOF
+
+  $ cat >subdir/two.ny <<EOF
+  > require "one.ny"
+  > axiom a : A
+  > EOF
+
+  $ narya -v -e 'require "subdir/two.ny"'
+   ￫ info[I0003]
+   ￮ loading file: $TESTCASE_ROOT/subdir/two.ny
+  
+   ￫ info[I0003]
+   ￮ loading file: $TESTCASE_ROOT/subdir/one.ny
+  
+   ￫ info[I0001]
+   ￮ Axiom A assumed
+  
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/subdir/one.ny
+  
+   ￫ info[I0001]
+   ￮ Axiom a assumed
+  
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/subdir/two.ny
+  
+
+A file isn't loaded twice even if referred to in different ways
+
+  $ narya -v subdir/one.ny -e 'require "subdir/two.ny"'
+   ￫ info[I0001]
+   ￮ Axiom A assumed
+  
+   ￫ info[I0003]
+   ￮ loading file: $TESTCASE_ROOT/subdir/two.ny
+  
+   ￫ info[I0001]
+   ￮ Axiom a assumed
+  
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/subdir/two.ny
+  

--- a/test/black/require.t
+++ b/test/black/require.t
@@ -205,3 +205,38 @@ A file isn't loaded twice even if referred to in different ways
    ￫ info[I0004]
    ￮ file loaded: $TESTCASE_ROOT/subdir/two.ny
   
+
+Notations are imported from explicitly required files, but not transitively.
+
+  $ cat >n1.ny <<EOF
+  > axiom A:Type
+  > axiom f : A -> A -> A
+  > axiom a:A
+  > EOF
+
+  $ cat >n2.ny <<EOF
+  > require "n1.ny"
+  > notation 0 f : x "&" y := f x y
+  > EOF
+
+  $ cat >n3.ny <<EOF
+  > require "n1.ny"
+  > require "n2.ny"
+  > notation 0 f2 : x "%" y := f x y
+  > EOF
+
+  $ narya n1.ny n3.ny -e 'echo a % a'
+  a % a
+    : A
+  
+
+  $ narya n1.ny n3.ny -e 'echo a & a'
+  a
+    : A
+  
+   ￫ error[E0200]
+   ￭ command-line exec string
+   1 | echo a & a
+     ^ parse error
+  
+  [1]

--- a/test/parser/commands.t
+++ b/test/parser/commands.t
@@ -43,5 +43,5 @@ Redefining commands
 
   $ narya -e 'axiom A:Type' -e 'axiom A:Type'
    ￫ warning[E2100]
-   ￮ redefining constant: A
+   ￮ name already defined: A
   

--- a/test/parser/notations.t
+++ b/test/parser/notations.t
@@ -1,6 +1,6 @@
 Testing notation commands
 
-  $ narya -v -e 'axiom A:Type' -e 'axiom f:A->A->A' -e 'notation 0 f : x "&" y := f x y'
+  $ narya -v -e 'axiom A:Type' -e 'axiom f:A->A->A' -e 'notation 0 f : x "&" y := f x y' -e 'def ff (x y : A) : A := x & y' -e 'axiom a : A' -e 'echo ff a a'
    ￫ info[I0001]
    ￮ Axiom A assumed
   
@@ -9,6 +9,15 @@ Testing notation commands
   
    ￫ info[I0002]
    ￮ Notation f defined
+  
+   ￫ info[I0000]
+   ￮ Constant ff defined
+  
+   ￫ info[I0001]
+   ￮ Axiom a assumed
+  
+  a & a
+    : A
   
 
   $ narya -e 'axiom A:Type' -e 'axiom f:A->A->A' -e 'notation 0 f : x "&" y.z := f x y.z'
@@ -57,7 +66,7 @@ Testing notation commands
   
   [1]
 
-  $ narya -e 'axiom A:Type' -e 'axiom f:A->A->A' -e 'notation 0.5 f : x "&" y := f x y'
+  $ narya -e 'axiom A:Type' -e 'axiom f:A->A->A' -e 'notation 0.5 f : x "&" y := f x y' -e 'def ff (x y : A) : A := x & y'
 
 
   $ narya -e 'axiom A:Type' -e 'axiom f:A->A->A' -e 'notation 0.1 f : x "&" y := f x y'
@@ -118,7 +127,13 @@ Testing notation commands
   
   [1]
 
-  $ narya -e 'axiom A:Type' -e 'axiom f:A->A->A' -e 'notation 0 f : x "&" y := f x y' -e 'notation 0 f2 : x "%" y := f x y'
+  $ narya -e 'axiom A:Type' -e 'axiom f:A->A->A' -e 'notation 0 f : x "&" y := f x y' -e 'notation 0 f2 : x "%" y := f x y' -e 'def ff (x y : A) : A := x & y' -e 'def ff2 (x y : A) : A := x % y' -e 'axiom a : A' -e 'echo ff a a' -e 'echo ff2 a a'
    ￫ warning[E2211]
    ￮ replacing printing notation for f (previous notation will still be parseable)
+  
+  a % a
+    : A
+  
+  a % a
+    : A
   

--- a/test/parser/permute_args.ml
+++ b/test/parser/permute_args.ml
@@ -9,9 +9,10 @@ let () =
   assume "A" "Type";
   assume "foo" "A → A → A";
   let foo = Option.get (Scope.lookup [ "foo" ]) in
-  State.Current.add_user "amp" (Infix No.zero)
-    [ `Var ("x", `Nobreak, []); `Op (Op "&", `Break, []); `Var ("y", `None, []) ]
-    (`Constant foo) [ "y"; "x" ];
+  let _ =
+    State.Current.add_user "amp" (Infix No.zero)
+      [ `Var ("x", `Nobreak, []); `Op (Op "&", `Break, []); `Var ("y", `None, []) ]
+      (`Constant foo) [ "y"; "x" ] in
   assume "a" "A";
   assume "b" "A";
   equal_at "foo a b" "b & a" "A";

--- a/test/testutil/repl.ml
+++ b/test/testutil/repl.ml
@@ -37,8 +37,7 @@ let assume (name : string) (ty : string) : unit =
   let p = Parse.Term.parse (`String { title = Some "constant name"; content = name }) in
   match Parse.Term.final p with
   | Term { value = Ident (name, _); _ } ->
-      if Option.is_some (Scope.lookup name) then
-        emit (Constant_already_defined (String.concat "." name));
+      Parser.Command.check_constant_name name;
       let const = Scope.define name in
       Reporter.try_with ~fatal:(fun d ->
           Scope.modify_visible (Yuujinchou.Language.except name);
@@ -55,8 +54,7 @@ let def (name : string) (ty : string) (tm : string) : unit =
   match Parse.Term.final p with
   | Term { value = Ident (name, _); _ } ->
       Reporter.tracef "when defining %s" (String.concat "." name) @@ fun () ->
-      if Option.is_some (Scope.lookup name) then
-        emit (Constant_already_defined (String.concat "." name));
+      Parser.Command.check_constant_name name;
       let const = Scope.define name in
       Reporter.try_with ~fatal:(fun d ->
           Scope.modify_visible (Yuujinchou.Language.except name);

--- a/test/testutil/repl.ml
+++ b/test/testutil/repl.ml
@@ -41,8 +41,8 @@ let assume (name : string) (ty : string) : unit =
         emit (Constant_already_defined (String.concat "." name));
       let const = Scope.define name in
       Reporter.try_with ~fatal:(fun d ->
-          Scope.S.modify_visible (Yuujinchou.Language.except name);
-          Scope.S.modify_export (Yuujinchou.Language.except name);
+          Scope.modify_visible (Yuujinchou.Language.except name);
+          Scope.modify_export (Yuujinchou.Language.except name);
           Reporter.fatal_diagnostic d)
       @@ fun () ->
       let rty = parse_term ty in
@@ -59,8 +59,8 @@ let def (name : string) (ty : string) (tm : string) : unit =
         emit (Constant_already_defined (String.concat "." name));
       let const = Scope.define name in
       Reporter.try_with ~fatal:(fun d ->
-          Scope.S.modify_visible (Yuujinchou.Language.except name);
-          Scope.S.modify_export (Yuujinchou.Language.except name);
+          Scope.modify_visible (Yuujinchou.Language.except name);
+          Scope.modify_export (Yuujinchou.Language.except name);
           Reporter.fatal_diagnostic d)
       @@ fun () ->
       let rty = parse_term ty in
@@ -129,18 +129,17 @@ let run f =
   Parser.Unparse.install ();
   Eternity.run_empty @@ fun () ->
   Global.run_empty @@ fun () ->
-  Scope.run @@ fun () ->
   Builtins.run @@ fun () ->
   Printconfig.run ~env:{ style = `Compact; state = `Term; chars = `Unicode } @@ fun () ->
+  Readback.Display.run ~env:false @@ fun () ->
+  Discreteness.run ~env:false @@ fun () ->
+  Discrete.run ~init:Constant.Map.empty @@ fun () ->
   Reporter.run ~emit:Terminal.display ~fatal:(fun d ->
       Terminal.display d;
       raise (Failure "Fatal error"))
   @@ fun () ->
-  Readback.Display.run ~env:false @@ fun () ->
-  Discreteness.run ~env:false @@ fun () ->
-  Discrete.run ~init:Constant.Map.empty @@ fun () ->
-  Parser.Pi.install ();
-  f ()
+  let init_visible = Parser.Pi.install Scope.Trie.empty in
+  Scope.run ~init_visible @@ fun () -> f ()
 
 let gel_install () =
   def "Gel" "(A B : Type) (R : A → B → Type) → Id Type A B" "A B R ↦ sig a b ↦ ( ungel : R a b )"


### PR DESCRIPTION
Adds an `import` command that loads another file.  Still no namespace management, library resolution, or separate compilation, but we do treat correctly the case of a single file imported multiple times.  See the readme for a few more details.

Incompatible changes:
- Definitions and notations no longer carry over automatically between multiple files given to a single invocation of Narya; you have to explicitly `import` them.  (This was always a kludgy stopgap until we had an actual import command.)  Definitions do still carry over automatically to `-e` strings and into interactive mode.
- The command `quit` no longer quits the entire program, it only terminates execution of the current file.