### PR TITLE
Save and load typechecked versions of files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Narya is eventually intended to be a proof assistant implementing Multi-Modal, Multi-Directional, Higher/Parametric/Displayed Observational Type Theory, but a formal type theory combining all those adjectives has not yet been specified.  At the moment, Narya implements a normalization-by-evaluation algorithm and typechecker for an observational-style theory with Id/Bridge types satisfying parametricity, of variable arity and internality.  There is a parser with user-definable mixfix notations, and user-definable record types, inductive datatypes and type families, and coinductive codatatypes, with functions definable by matching and comatching case trees.
 
-Narya is very much a work in progress.  Expect breaking changes, including even in fundamental aspects of the syntax.  But on the other side of the coin, feedback on anything and everything is welcome.  In particular, please report all crashes, bugs, unexpected errors, and other unexpected, surprising, or unintuitive behavior.
+Narya is very much a work in progress.  Expect breaking changes, including even in fundamental aspects of the syntax.  (I try to make breaking changes as GitHub pull requests, so if you watch the repository you should at least get notified of them.)  But on the other side of the coin, feedback on anything and everything is welcome.  In particular, please report all crashes, bugs, unexpected errors, and other unexpected, surprising, or unintuitive behavior, either in GitHub issues or by direct email.
 
 
 ## Top level interface
@@ -16,7 +16,7 @@ opam switch create 5.2.0
 opam install zarith uuseg bwd algaeff asai yuujinchou react lwt lambda-term fmlib
 
 cd ../narya
-dune build @install
+dune build
 dune runtest
 dune install
 ```
@@ -33,6 +33,7 @@ The Narya executable accepts at least the following command-line flags.
 - `-interactive` or `-i`: Enter interactive mode (see below)
 - `-exec STRING` or `-e STRING`: Execute a string argument (see below)
 - `-no-check`: Don't typecheck and execute code (only parse it)
+- `-source-only`: Load all files from source, ignoring any compiled versions
 
 #### Formatting output
 
@@ -53,9 +54,7 @@ These options are discussed further below.
 
 ### Execution
 
-When the Narya executable is run, it loads all the files given on its command line and any strings supplied on the command line with `-e`.  As usual, the special filename `-` refers to standard input.  Files and strings are loaded in the order they are given on the command line.  Lastly, if `-i` was given anywhere on the command line, Narya enters interactive mode.
-
-When in interactive mode or loading a command-line `-e` string, all definitions from all files and strings specified previously on the command line are available (but not those loaded transitively by `import`).  However, when loading a file (including standard input), definitions from other files are not available by default, even if those files were specified earlier on the command line; you have to explicitly `import` them (see below).  There is no compilation or caching yet: everything must be typechecked and loaded anew at every invocation.
+When the Narya executable is run, it loads all the files given on its command line and any strings supplied on the command line with `-e`.  As usual, the special filename `-` refers to standard input.  Files and strings are loaded in the order they are given on the command line; all files must have the extension `.ny`.  Lastly, if `-i` was given anywhere on the command line, Narya enters interactive mode.
 
 In interactive mode, commands typed by the user are executed as they are entered.  Since many commands span multiple lines, Narya waits for a blank line before parsing and executing the command(s) being entered.  Make sure to enter a blank line before starting a new command; interactive commands must be entered and executed one at a time.  The result of the command is printed (more verbosely than is usual when loading a file) and then the user can enter more commands.  Type Control+D to exit interactive mode, or enter the command `quit`.  In addition, in interactive mode you can enter a term instead of a command, and Narya will assume you mean to `echo` it (see below).
 
@@ -82,14 +81,25 @@ In a file, conventionally each command begins on a new line, but this is not tec
 
 5. `import FILE`
 
-   Add the extension `.ny` to the double-quoted string `FILE`, execute the file at that location (either absolute or relative to the location of the current file), and add its definitions and notations to the current namespace.  That is, the disk file *must* have the `.ny` extension, whereas the string given to `import` must *not* have it; this is because in the future the string given to `import` will be a more general "library identifier" in the [bantorra](https://redprl.org/bantorra/bantorra/index.html) framework.
-
-   The commands in `FILE.ny` cannot access any definitions from other files, including the current one, except those that it imports itself; and the definitions and notations from files imported by `FILE.ny` are not added to the current namespace (unless it also imports those files directly).  No file will be executed more than once during a single run, even if it is imported by multiple other files.  Circular imports are not allowed.
+   Add the extension `.ny` to the double-quoted string `FILE` and import the file at that location (either absolute or relative to the location of the current file).  The disk file *must* have the `.ny` extension, whereas the string given to `import` must *not* have it; this is because in the future the string given to `import` will be a more general "library identifier" in the [bantorra](https://redprl.org/bantorra/bantorra/index.html) framework.
 
 6. `quit`
 
    Terminate execution of the current compilation unit.  Whenever this command is found, loading of the current file or command-line string ceases, just as if the file or string had ended right there.  Execution then continues as usual with any file that imported the current one, with the next file or string on the command line, or with interactive mode if that was requested.  The command `quit` in interactive mode exits the program (you can also exit interactive mode by typing Control+D).
    
+
+### Imports and compilation
+
+As noted above, the command `import` executes another Narya file and adds its definitions and notations to the current namespace.  The commands in the imported file cannot access any definitions from other files, including the current one, except those that it imports itself.  Importing is not transitive: if `a.ny` imports `b.ny`, and `b.ny` imports `c.ny`, then the definitions from `c.ny` do not appear in the namespace of `a.ny` unless it also imports `c.ny` explicitly.
+
+By contrast, when in interactive mode or executing a command-line `-e` string, all definitions from all files and strings that were explicitly specified previously on the command line are available.  This does not carry over transitively to files imported by those.  Standard input (indicated by `-` on the command line) is treated as an ordinary file and must import any other files it wants to use.
+
+No file will be executed more than once during a single run, even if it is imported by multiple other files.  Thus, if both `b.ny` and `c.ny` import `d.ny`, and `a.ny` imports both `b.ny` and `c.ny`, any effectual commands like `echo` in `d.ny` will only happen once, there will only be one copy of the definitions from `d.ny` in the namespace of `a.ny`, and the definitions from `b.ny` and `c.ny` are compatible.  Circular imports are not allowed (and are checked for).
+
+In addition, whenever a file `FILE.ny` is successfully executed, Narya writes a "compiled" version of that file in the same directory called `FILE.nyo`.  Then whenever `FILE.ny` is to be executed again, either because it was specified on the command line or imported by another file, if `FILE.nyo` exists next to it and `FILE.ny` has not been modified more recently than `FILE.nyo`, and none of the files imported by `FILE.ny` are newer than it or their compiled versions, then `FILE.nyo` is loaded directly instead of re-executing `FILE.ny`, skipping the typechecking step.  This can be much faster.  But if desired, it can be turned off with the `-source-only` flag.
+
+Currently, effectual commands like `echo` are *not* re-executed when a file loaded from its compiled version (they are not even stored in the compiled version).  Thus, if you executed a file to see its output, and you want to run it again to see the same output again, you have to either modify the file or use `-source-only` and wait for it to be re-typechecked as well.  This may change in the future.
+
 
 ## Built-in types
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,15 @@ By contrast, when in interactive mode or executing a command-line `-e` string, a
 
 No file will be executed more than once during a single run, even if it is imported by multiple other files.  Thus, if both `b.ny` and `c.ny` import `d.ny`, and `a.ny` imports both `b.ny` and `c.ny`, any effectual commands like `echo` in `d.ny` will only happen once, there will only be one copy of the definitions from `d.ny` in the namespace of `a.ny`, and the definitions from `b.ny` and `c.ny` are compatible.  Circular imports are not allowed (and are checked for).
 
-In addition, whenever a file `FILE.ny` is successfully executed, Narya writes a "compiled" version of that file in the same directory called `FILE.nyo`.  Then whenever `FILE.ny` is to be executed again, either because it was specified on the command line or imported by another file, if `FILE.nyo` exists next to it and `FILE.ny` has not been modified more recently than `FILE.nyo`, and none of the files imported by `FILE.ny` are newer than it or their compiled versions, then `FILE.nyo` is loaded directly instead of re-executing `FILE.ny`, skipping the typechecking step.  This can be much faster.  But if desired, it can be turned off with the `-source-only` flag.
+In addition, whenever a file `FILE.ny` is successfully executed, Narya writes a "compiled" version of that file in the same directory called `FILE.nyo`.  Then whenever `FILE.ny` is to be executed again, either because it was specified on the command line or imported by another file, if
+
+1. `-source-only` was not specified,
+1. `FILE.nyo` exists in the same directory,
+2. the same type theory flags (`-arity`, `-direction`, `-internal`/`-external`, and `-discreteness`) are in effect now as when `FILE.nyo` was compiled,
+3. `FILE.ny` has not been modified more recently than `FILE.nyo`, and
+4. none of the files imported by `FILE.ny` are newer than it or their compiled versions,
+
+then `FILE.nyo` is loaded directly instead of re-executing `FILE.ny`, skipping the typechecking step.  This can be much faster.  If any of these conditions fail, then `FILE.ny` is executed from source as usual, and a new compiled version `FILE.nyo` is saved, overwriting the previous one.
 
 Currently, effectual commands like `echo` are *not* re-executed when a file loaded from its compiled version (they are not even stored in the compiled version).  Thus, if you executed a file to see its output, and you want to run it again to see the same output again, you have to either modify the file or use `-source-only` and wait for it to be re-typechecked as well.  This may change in the future.
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ In addition, whenever a file `FILE.ny` is successfully executed, Narya writes a 
 
 then `FILE.nyo` is loaded directly instead of re-executing `FILE.ny`, skipping the typechecking step.  This can be much faster.  If any of these conditions fail, then `FILE.ny` is executed from source as usual, and a new compiled version `FILE.nyo` is saved, overwriting the previous one.
 
-Currently, effectual commands like `echo` are *not* re-executed when a file loaded from its compiled version (they are not even stored in the compiled version).  Thus, if you executed a file to see its output, and you want to run it again to see the same output again, you have to either modify the file or use `-source-only` and wait for it to be re-typechecked as well.  This may change in the future.
+At least currently, effectual commands like `echo` are *not* re-executed when a file loaded from its compiled version (they are not even stored in the compiled version).  Thus, if you executed a file to see its output, and you want to run it again to see the same output again, you have to either modify the file or use `-source-only` and wait for it to be re-typechecked as well.
 
 
 ## Built-in types

--- a/bin/narya.ml
+++ b/bin/narya.ml
@@ -94,7 +94,12 @@ let rec batch first ws p src =
 let execute init_visible (source : Asai.Range.source) =
   if !reformat then Format.open_vbox 0;
   Units.run ~init_visible @@ fun () ->
+  let compunit =
+    match source with
+    | `File _ -> Compunit.make ()
+    | `String _ -> Compunit.basic in
   let p, src = Command.Parse.start_parse source in
+  Compunit.Current.run ~env:compunit @@ fun () ->
   Reporter.try_with
     (fun () ->
       let ws = batch true [] p src in
@@ -235,6 +240,7 @@ let () =
   Dim.Endpoints.set_internal !internal;
   (* The initial namespace for all compilation units. *)
   let init = Parser.Pi.install Scope.Trie.empty in
+  Compunit.Current.run ~env:Compunit.basic @@ fun () ->
   Units.with_compile init execute @@ fun () ->
   Mbwd.miter
     (fun [ input ] ->

--- a/bin/narya.ml
+++ b/bin/narya.ml
@@ -1,7 +1,6 @@
 open Bwd
 open Util
 open Core
-open Reporter
 open Parser
 open Format
 open React
@@ -92,15 +91,9 @@ let rec batch first ws p src =
     let p, src = Command.Parse.restart_parse p src in
     batch false ws p src)
 
-let execute init_visible (source : Asai.Range.source) =
+let execute init_visible compunit (source : Asai.Range.source) =
   if !reformat then Format.open_vbox 0;
   Units.run ~init_visible @@ fun () ->
-  let compunit =
-    match source with
-    | `File file ->
-        if FilePath.is_relative file then fatal (Anomaly "relative file path in execute");
-        Compunit.make file
-    | `String _ -> Compunit.basic in
   let p, src = Command.Parse.start_parse source in
   Compunit.Current.run ~env:compunit @@ fun () ->
   Reporter.try_with
@@ -119,7 +112,7 @@ let execute init_visible (source : Asai.Range.source) =
             | `String { title; _ } -> title in
           Reporter.emit (Quit src)
       | _ -> Reporter.fatal_diagnostic d);
-  (Scope.get_export (), compunit)
+  Scope.get_export ()
 
 let ( let* ) f o = Lwt.bind f o
 

--- a/bin/narya.ml
+++ b/bin/narya.ml
@@ -116,7 +116,7 @@ let execute init_visible (source : Asai.Range.source) =
             | `String { title; _ } -> title in
           Reporter.emit (Quit src)
       | _ -> Reporter.fatal_diagnostic d);
-  Scope.get_export ()
+  (Scope.get_export (), compunit)
 
 let ( let* ) f o = Lwt.bind f o
 

--- a/bin/narya.ml
+++ b/bin/narya.ml
@@ -22,6 +22,7 @@ let refl_char = ref 'e'
 let refl_strings = ref [ "refl"; "Id" ]
 let internal = ref true
 let discreteness = ref false
+let source_only = ref false
 
 let set_refls str =
   match String.split_on_char ',' str with
@@ -56,6 +57,7 @@ let speclist =
     ("-internal", Arg.Set internal, "Set parametricity to internal (default)");
     ("-external", Arg.Clear internal, "Set parametricity to external");
     ("-discreteness", Arg.Set discreteness, "Enable discreteness");
+    ("-source-only", Arg.Set source_only, "Load all files from source (ignore compiled versions)");
     ( "-dtt",
       Unit
         (fun () ->
@@ -237,7 +239,7 @@ let () =
   (* The initial namespace for all compilation units. *)
   let init = Parser.Pi.install Scope.Trie.empty in
   Compunit.Current.run ~env:Compunit.basic @@ fun () ->
-  Units.with_execute init execute @@ fun () ->
+  Units.with_execute !source_only init execute @@ fun () ->
   Mbwd.miter
     (fun [ input ] ->
       match input with

--- a/bin/narya.ml
+++ b/bin/narya.ml
@@ -241,14 +241,13 @@ let () =
   Mbwd.miter
     (fun [ input ] ->
       match input with
-      | `File filename -> Units.load (`File filename)
+      | `File filename -> Units.load_file filename
       | `Stdin ->
           let content = In_channel.input_all stdin in
-          Units.load (`String { content; title = Some "stdin" })
+          Units.load_string (Some "stdin") content None
       (* Command-line strings have all the previous units loaded without needing to 'require' them. *)
       | `String content ->
-          Units.load ~init:(Units.all ())
-            (`String { content; title = Some "command-line exec string" }))
+          Units.load_string (Some "command-line exec string") content (Some (Units.all ())))
     [ !inputs ];
   (* Interactive mode also has all the other units loaded. *)
   if !interactive then

--- a/bin/narya.ml
+++ b/bin/narya.ml
@@ -244,7 +244,7 @@ let () =
   (* The initial namespace for all compilation units. *)
   let init = Parser.Pi.install Scope.Trie.empty in
   Compunit.Current.run ~env:Compunit.basic @@ fun () ->
-  Units.with_compile init execute @@ fun () ->
+  Units.with_execute init execute @@ fun () ->
   Mbwd.miter
     (fun [ input ] ->
       match input with

--- a/bin/narya.ml
+++ b/bin/narya.ml
@@ -1,6 +1,7 @@
 open Bwd
 open Util
 open Core
+open Reporter
 open Parser
 open Format
 open React
@@ -96,7 +97,9 @@ let execute init_visible (source : Asai.Range.source) =
   Units.run ~init_visible @@ fun () ->
   let compunit =
     match source with
-    | `File _ -> Compunit.make ()
+    | `File file ->
+        if FilePath.is_relative file then fatal (Anomaly "relative file path in execute");
+        Compunit.make file
     | `String _ -> Compunit.basic in
   let p, src = Command.Parse.start_parse source in
   Compunit.Current.run ~env:compunit @@ fun () ->

--- a/bin/narya.ml
+++ b/bin/narya.ml
@@ -262,7 +262,14 @@ let () =
   (* The initial namespace for all compilation units. *)
   let init = Parser.Pi.install Scope.Trie.empty in
   Compunit.Current.run ~env:Compunit.basic @@ fun () ->
-  Units.with_execute !source_only init execute @@ fun () ->
+  let top_files =
+    Bwd.fold_right
+      (fun input acc ->
+        match input with
+        | `File file -> FilePath.make_absolute (Sys.getcwd ()) file :: acc
+        | _ -> acc)
+      !inputs [] in
+  Units.with_execute !source_only top_files init execute @@ fun () ->
   Mbwd.miter
     (fun [ input ] ->
       match input with

--- a/lib/core/check.ml
+++ b/lib/core/check.ml
@@ -428,7 +428,8 @@ let rec check :
   (* If the user left a hole, we create an eternal metavariable. *)
   | Hole vars, _ ->
       let energy = energy status in
-      let meta = Meta.make `Hole (Ctx.dbwd ctx) energy in
+      (* Holes aren't numbered by the file they appear in. *)
+      let meta = Meta.make Compunit.basic `Hole (Ctx.dbwd ctx) energy in
       let ty, termctx =
         Readback.Display.run ~env:true @@ fun () -> (readback_val ctx ty, readback_ctx ctx) in
       Eternity.add meta vars termctx ty energy;
@@ -461,7 +462,7 @@ and kinetic_of_potential :
   | `Let -> raise Case_tree_construct_in_let
   | `Nolet ->
       emit (Bare_case_tree_construct sort);
-      let meta = Meta.make (`Def (sort, None)) (Ctx.dbwd ctx) Potential in
+      let meta = Meta.make (Compunit.Current.read ()) (`Def (sort, None)) (Ctx.dbwd ctx) Potential in
       let tmstatus = Potential (Meta (meta, Ctx.env ctx), Emp, fun x -> x) in
       let cv = check tmstatus ctx tm ty in
       let vty = readback_val ctx ty in
@@ -490,7 +491,8 @@ and synth_or_check_let :
     (* If that fails, the bound term is also allowed to be a case tree, i.e. a potential term.  But in a checked "let" expression, the term being bound is a kinetic one, and must be so that its value can be put into the environment when the term is evaluated.  We deal with this by binding a *metavariable* to the bound term and then taking the value of that metavariable as the kinetic term to actually be bound.  *)
     | Case_tree_construct_in_let ->
       (* First we make the metavariable. *)
-      let meta = Meta.make (`Def ("let", name)) (Ctx.dbwd ctx) Potential in
+      let meta =
+        Meta.make (Compunit.Current.read ()) (`Def ("let", name)) (Ctx.dbwd ctx) Potential in
       (* A new status in which to check the value of that metavariable; now it is the "current constant" being defined. *)
       let tmstatus = Potential (Meta (meta, Ctx.env ctx), Emp, fun x -> x) in
       let sv, svty = synth tmstatus ctx v in
@@ -1399,7 +1401,9 @@ and synth :
       | `Nolet ->
           emit (Bare_case_tree_construct "match");
           (* A match in a kinetic synthesizing position, we can treat like a let-binding that returns the bound (metavariable) value.  Of course we can shortcut the binding by just inserting the metavariable as the result.  This code is copied and slightly modified from synth_or_check_let.  *)
-          let meta = Meta.make (`Def ("match", None)) (Ctx.dbwd ctx) Potential in
+          let meta =
+            Meta.make (Compunit.Current.read ()) (`Def ("match", None)) (Ctx.dbwd ctx) Potential
+          in
           let tmstatus = Potential (Meta (meta, Ctx.env ctx), Emp, fun x -> x) in
           let sv, svty = synth tmstatus ctx tm in
           let vty = readback_val ctx svty in

--- a/lib/core/check.ml
+++ b/lib/core/check.ml
@@ -1353,7 +1353,7 @@ and synth :
           | Some v -> (realize status (Term.Field (Var v, fld)), tyof_field x.tm x.ty fld)
           | None -> fatal (Anomaly "level not found in field view")))
   | Const name, _ ->
-      let ty, _ = Global.find_opt name <|> Undefined_constant (PConstant name) in
+      let ty, _ = Global.find name in
       (realize status (Const name), eval_term (Emp D.zero) ty)
   | Field (tm, fld), _ ->
       let stm, sty = synth (Kinetic `Nolet) ctx tm in

--- a/lib/core/command.ml
+++ b/lib/core/command.ml
@@ -85,6 +85,7 @@ let execute : t -> unit = function
       let h = Eternity.end_command () in
       emit (Constant_assumed (PConstant const, h))
   | Def defs ->
+      (* The Discrete map is supposed to include all the constants currently being defined, but we start them all out set to false since we haven't yet checked that any of them are discrete. *)
       let init =
         List.fold_left (fun map (c, _) -> map |> Constant.Map.add c false) Constant.Map.empty defs
       in
@@ -94,5 +95,10 @@ let execute : t -> unit = function
       check_defs defs;
       let h = Eternity.end_command () in
       let printables =
-        List.map (fun (c, _) -> (PConstant c, Constant.Map.find c (Discrete.get ()))) defs in
+        List.map
+          (fun (c, _) ->
+            ( PConstant c,
+              Constant.Map.find_opt c (Discrete.get ())
+              <|> Anomaly "undefined just-defined constant" ))
+          defs in
       emit (Constant_defined (printables, h))

--- a/lib/core/compunit.ml
+++ b/lib/core/compunit.ml
@@ -1,0 +1,39 @@
+(* This module should not be opened, but be used qualified. *)
+
+(* A compilation unit is identified by an autonumber. *)
+module Compunit = struct
+  type t = int
+
+  let compare : t -> t -> int = compare
+end
+
+type t = Compunit.t
+
+let counter = ref 0
+
+(* The zeroth compilation unit includes predefined constants as well as those from command-line exec strings, stdin, and interactive mode. *)
+let basic : t = 0
+
+let make () : t =
+  counter := !counter + 1;
+  !counter
+
+(* Constants and metavariables are identified by their compilation unit together with another autonumber.  We can store those autonumber counters in dynamic arrays, since compilation units are integers and can be used as array indices.  To avoid exposing the definition of Compunit.t as int outside this module, we expose a dynamic array module that does just what we need. *)
+module IntArray = struct
+  type t = int Dynarray.t
+
+  let make_basic () = Dynarray.make 1 (-1)
+  let get a i = Dynarray.get a i
+
+  let inc a i =
+    (if i >= Dynarray.length a then
+       let k = i - Dynarray.length a + 1 in
+       Dynarray.append_seq a (Seq.init k (fun _ -> -1)));
+    Dynarray.set a i (Dynarray.get a i + 1);
+    Dynarray.get a i
+end
+
+module Map = Map.Make (Compunit)
+
+(* The current compilation unit, used for creating new constants and metavariables, is exposed through a reader effect. *)
+module Current = Algaeff.Reader.Make (Compunit)

--- a/lib/core/compunit.ml
+++ b/lib/core/compunit.ml
@@ -10,13 +10,17 @@ end
 type t = Compunit.t
 
 let counter = ref 0
+let by_file : (string, t) Hashtbl.t = Hashtbl.create 20
 
 (* The zeroth compilation unit includes predefined constants as well as those from command-line exec strings, stdin, and interactive mode. *)
 let basic : t = 0
 
-let make () : t =
+let make file : t =
   counter := !counter + 1;
+  Hashtbl.add by_file file !counter;
   !counter
+
+let get file = Hashtbl.find by_file file
 
 (* Constants and metavariables are identified by their compilation unit together with another autonumber.  We can store those autonumber counters in dynamic arrays, since compilation units are integers and can be used as array indices.  To avoid exposing the definition of Compunit.t as int outside this module, we expose a dynamic array module that does just what we need. *)
 module IntArray = struct

--- a/lib/core/compunit.mli
+++ b/lib/core/compunit.mli
@@ -7,7 +7,8 @@ end
 type t = Compunit.t
 
 val basic : t
-val make : unit -> t
+val make : string -> t
+val get : string -> t
 
 module IntArray : sig
   type t

--- a/lib/core/compunit.mli
+++ b/lib/core/compunit.mli
@@ -1,0 +1,21 @@
+module Compunit : sig
+  type t
+
+  val compare : t -> t -> int
+end
+
+type t = Compunit.t
+
+val basic : t
+val make : unit -> t
+
+module IntArray : sig
+  type t
+
+  val make_basic : unit -> t
+  val get : t -> Compunit.t -> int
+  val inc : t -> Compunit.t -> int
+end
+
+module Map : module type of Map.Make (Compunit)
+module Current : module type of Algaeff.Reader.Make (Compunit)

--- a/lib/core/constant.ml
+++ b/lib/core/constant.ml
@@ -17,6 +17,8 @@ let make compunit : t =
   let number = Compunit.IntArray.inc counters compunit in
   (compunit, number)
 
+let remake f (c, i) = (f c, i)
+
 (* Data associated to constants is also stored in a map whose domain is their paired identities. *)
 module Map = struct
   module IntMap = Map.Make (Int)

--- a/lib/core/constant.ml
+++ b/lib/core/constant.ml
@@ -12,4 +12,6 @@ let make () : t =
   counter := !counter + 1;
   !counter
 
-module Map = Map.Make (Constant)
+module Map = struct
+  include Map.Make (Constant)
+end

--- a/lib/core/constant.ml
+++ b/lib/core/constant.ml
@@ -1,17 +1,59 @@
+open Util
+
+(* This module should not be opened, but be used qualified. *)
+
+(* A constant is identified by an autonumber, scoped by compilation unit. *)
 module Constant = struct
-  type t = int
+  type t = Compunit.t * int
 
   let compare (x : t) (y : t) = compare x y
 end
 
 type t = Constant.t
 
-let counter = ref (-1)
+let counters = Compunit.IntArray.make_basic ()
 
-let make () : t =
-  counter := !counter + 1;
-  !counter
+let make compunit : t =
+  let number = Compunit.IntArray.inc counters compunit in
+  (compunit, number)
 
+(* Data associated to constants is also stored in a map whose domain is their paired identities. *)
 module Map = struct
-  include Map.Make (Constant)
+  module IntMap = Map.Make (Int)
+  module Map = Compunit.Map
+
+  type 'a t = 'a IntMap.t Map.t
+
+  let empty : 'a t = Map.empty
+
+  let find_opt (i, c) m =
+    let open Monad.Ops (Monad.Maybe) in
+    let* m = Map.find_opt i m in
+    IntMap.find_opt c m
+
+  let mem (i, c) m =
+    match Map.find_opt i m with
+    | Some m -> IntMap.mem c m
+    | None -> false
+
+  let add (i, c) x m =
+    Map.update i
+      (function
+        | None -> Some (IntMap.empty |> IntMap.add c x)
+        | Some m -> Some (IntMap.add c x m))
+      m
+
+  let update (i, c) f m =
+    Map.update i
+      (function
+        | None -> Some (IntMap.update c f IntMap.empty)
+        | Some m -> Some (IntMap.update c f m))
+      m
+
+  let remove (i, c) m =
+    Map.update i
+      (function
+        | None -> None
+        | Some m -> Some (IntMap.remove c m))
+      m
 end

--- a/lib/core/constant.mli
+++ b/lib/core/constant.mli
@@ -8,4 +8,12 @@ type t = Constant.t
 
 val make : unit -> t
 
-module Map : module type of Map.Make (Constant)
+module Map : sig
+  type 'a t
+
+  val empty : 'a t
+  val find_opt : Constant.t -> 'a t -> 'a option
+  val mem : Constant.t -> 'a t -> bool
+  val add : Constant.t -> 'a -> 'a t -> 'a t
+  val update : Constant.t -> ('a option -> 'a option) -> 'a t -> 'a t
+end

--- a/lib/core/constant.mli
+++ b/lib/core/constant.mli
@@ -7,6 +7,7 @@ end
 type t = Constant.t
 
 val make : Compunit.t -> t
+val remake : (Compunit.t -> Compunit.t) -> t -> t
 
 module Map : sig
   type 'a t

--- a/lib/core/constant.mli
+++ b/lib/core/constant.mli
@@ -18,4 +18,6 @@ module Map : sig
   val add : Constant.t -> 'a -> 'a t -> 'a t
   val update : Constant.t -> ('a option -> 'a option) -> 'a t -> 'a t
   val remove : Constant.t -> 'a t -> 'a t
+  val to_channel_unit : Out_channel.t -> Compunit.t -> 'a t -> Marshal.extern_flags list -> unit
+  val from_channel_unit : In_channel.t -> ('a -> 'a) -> Compunit.t -> 'a t -> 'a t
 end

--- a/lib/core/constant.mli
+++ b/lib/core/constant.mli
@@ -6,7 +6,7 @@ end
 
 type t = Constant.t
 
-val make : unit -> t
+val make : Compunit.t -> t
 
 module Map : sig
   type 'a t
@@ -16,4 +16,5 @@ module Map : sig
   val mem : Constant.t -> 'a t -> bool
   val add : Constant.t -> 'a -> 'a t -> 'a t
   val update : Constant.t -> ('a option -> 'a option) -> 'a t -> 'a t
+  val remove : Constant.t -> 'a t -> 'a t
 end

--- a/lib/core/equal.ml
+++ b/lib/core/equal.ml
@@ -179,8 +179,7 @@ module Equal = struct
     | Meta { meta = meta1; env = env1; ins = i1 }, Meta { meta = meta2; env = env2; ins = i2 } -> (
         match (Meta.compare meta1 meta2, D.compare (cod_left_ins i1) (cod_left_ins i2)) with
         | Eq, Eq ->
-            let (Metadef { termctx; _ }) =
-              Global.find_meta_opt meta1 <|> Undefined_metavariable (PMeta meta1) in
+            let (Metadef { termctx; _ }) = Global.find_meta meta1 in
             equal_env lvl env1 env2 termctx
         | _ -> fail)
     | _, _ -> fail

--- a/lib/core/eternity.ml
+++ b/lib/core/eternity.ml
@@ -3,6 +3,7 @@
 open Util
 open Syntax
 open Term
+open Reporter
 
 (* In contrast to the "Global" state which stores constants and their definitions, the "Eternal" state stores metavariables and their definitions.  Like its Asimovian namesake, Eternity exists outside the ordinary timestream.  Eternal metavariables aren't scoped and aren't affected by import and sectioning commands, but even more importantly, each such metavariable stores its own copy of the Global state when it was created.  This way we can "go back in time" to when that metavariable was created and be sure that any solution of that metavariable would have been valid in its original location. *)
 
@@ -19,7 +20,7 @@ type (_, _) metadef =
     }
       -> (unit, 'b * 's) metadef
 
-(* As with Global, we track Galactic state using a State effect.  In this case, the state is an intrinsically well-typed map, since metavariables are parametrized by their context length and energy. *)
+(* As with Global, we track Eternal state using a State effect.  In this case, the state is an intrinsically well-typed map, since metavariables are parametrized by their context length and energy. *)
 
 module Map = Meta.Map.Make (struct
   type ('x, 'bs) t = ('x, 'bs) metadef
@@ -34,7 +35,7 @@ end
 module S = Algaeff.State.Make (StateData)
 
 (* Don't use this directly!  Call Global.find_meta_opt, which passes off to this if it doesn't find a definitional-local metavariable. *)
-let find_opt meta = Map.find_opt (MetaKey meta) (S.get ()).map
+let find meta = Map.find_opt (MetaKey meta) (S.get ()).map <|> Undefined_metavariable (PMeta meta)
 
 let add :
     type a b s.

--- a/lib/core/eternity.ml
+++ b/lib/core/eternity.ml
@@ -20,6 +20,16 @@ type (_, _) metadef =
     }
       -> (unit, 'b * 's) metadef
 
+let link_def : type x y. (Compunit.t -> Compunit.t) -> (x, y) metadef -> (x, y) metadef =
+ fun f (Metadef d) ->
+  let termctx = Termctx.link f d.termctx in
+  let ty = Link.term f d.ty in
+  let tm =
+    match d.tm with
+    | `None -> `None
+    | `Nonrec tm -> `Nonrec (Link.term f tm) in
+  Metadef { d with termctx; ty; tm }
+
 (* As with Global, we track Eternal state using a State effect.  In this case, the state is an intrinsically well-typed map, since metavariables are parametrized by their context length and energy. *)
 
 module Map = Meta.Map.Make (struct

--- a/lib/core/eternity.mli
+++ b/lib/core/eternity.mli
@@ -18,7 +18,7 @@ module Map : module type of Meta.Map.Make (struct
   type ('x, 'bs) t = ('x, 'bs) metadef
 end)
 
-val find_opt : ('a, 'b) Meta.t -> (unit, 'a * 'b) metadef option
+val find : ('a, 'b) Meta.t -> (unit, 'a * 'b) metadef
 
 val add :
   ('b, 's) Meta.t ->

--- a/lib/core/eternity.mli
+++ b/lib/core/eternity.mli
@@ -14,6 +14,8 @@ type (_, _) metadef =
     }
       -> (unit, 'b * 's) metadef
 
+val link_def : (Compunit.t -> Compunit.t) -> ('x, 'y) metadef -> ('x, 'y) metadef
+
 module Map : module type of Meta.Map.Make (struct
   type ('x, 'bs) t = ('x, 'bs) metadef
 end)

--- a/lib/core/global.ml
+++ b/lib/core/global.ml
@@ -23,19 +23,19 @@ module S = Algaeff.State.Make (struct
   type t = data
 end)
 
-let find_opt c =
+let find c =
   let d = S.get () in
   match (Constant.Map.find_opt c d.constants, d.locked) with
   | Some (Ok (_, Axiom `Nonparametric)), true -> fatal (Locked_axiom (PConstant c))
-  | Some (Ok (ty, tm)), _ -> Some (ty, tm)
+  | Some (Ok (ty, tm)), _ -> (ty, tm)
   | Some (Error e), _ -> fatal e
-  | None, _ -> None
+  | None, _ -> fatal (Undefined_constant (PConstant c))
 
-let find_meta_opt m =
+let find_meta m =
   let d = S.get () in
   match Eternity.Map.find_opt (MetaKey m) d.metas with
-  | Some x -> Some x
-  | None -> Eternity.find_opt m
+  | Some x -> x
+  | None -> Eternity.find m
 
 let locked () = (S.get ()).locked
 

--- a/lib/core/global.ml
+++ b/lib/core/global.ml
@@ -37,6 +37,21 @@ let find_meta m =
   | Some x -> x
   | None -> Eternity.find m
 
+let to_channel_unit chan i flags =
+  let d = S.get () in
+  Constant.Map.to_channel_unit chan i d.constants flags;
+  Eternity.Map.to_channel_unit chan i d.metas flags
+
+let from_channel_unit f chan i =
+  let d = S.get () in
+  let constants =
+    Constant.Map.from_channel_unit chan
+      (Result.map (fun (tm, df) -> (Link.term f tm, df)))
+      i d.constants in
+  let metas =
+    Eternity.Map.from_channel_unit chan { map = (fun df -> Eternity.link_def f df) } i d.metas in
+  S.set { d with constants; metas }
+
 let locked () = (S.get ()).locked
 
 let add_to c ty df (d : data) =

--- a/lib/core/global.mli
+++ b/lib/core/global.mli
@@ -7,6 +7,8 @@ type definition = Axiom of [ `Parametric | `Nonparametric ] | Defined of (emp, p
 
 val find : Constant.t -> (emp, kinetic) term * definition
 val find_meta : ('b, 's) Meta.t -> (unit, 'b * 's) Eternity.metadef
+val to_channel_unit : Out_channel.t -> Compunit.t -> Marshal.extern_flags list -> unit
+val from_channel_unit : (Compunit.t -> Compunit.t) -> In_channel.t -> Compunit.t -> unit
 val locked : unit -> bool
 val run_empty : (unit -> 'a) -> 'a
 val add : Constant.t -> (emp, kinetic) term -> definition -> unit

--- a/lib/core/global.mli
+++ b/lib/core/global.mli
@@ -5,8 +5,8 @@ open Term
 
 type definition = Axiom of [ `Parametric | `Nonparametric ] | Defined of (emp, potential) term
 
-val find_opt : Constant.t -> ((emp, kinetic) term * definition) option
-val find_meta_opt : ('b, 's) Meta.t -> (unit, 'b * 's) Eternity.metadef option
+val find : Constant.t -> (emp, kinetic) term * definition
+val find_meta : ('b, 's) Meta.t -> (unit, 'b * 's) Eternity.metadef
 val locked : unit -> bool
 val run_empty : (unit -> 'a) -> 'a
 val add : Constant.t -> (emp, kinetic) term -> definition -> unit

--- a/lib/core/link.ml
+++ b/lib/core/link.ml
@@ -1,0 +1,64 @@
+open Util
+open Dim
+open Syntax
+open Term
+
+(* When "linking" a pre-compiled file with the current run, we need to walk the unmarshaled terms and replace the old autonumbers of compilation units, from when the file was compiled, with the current ones. *)
+
+let rec term : type a s. (Compunit.t -> Compunit.t) -> (a, s) term -> (a, s) term =
+ fun f tm ->
+  match tm with
+  | Var i -> Var i
+  | Const c -> Const (Constant.remake f c)
+  | Meta (m, s) -> Meta (Meta.remake f m, s)
+  | MetaEnv (m, e) -> MetaEnv (Meta.remake f m, env f e)
+  | Field (tm, fld) -> Field (term f tm, fld)
+  | UU n -> UU n
+  | Inst (tm, args) -> Inst (term f tm, TubeOf.mmap { map = (fun _ [ x ] -> term f x) } [ args ])
+  | Pi (x, doms, cods) ->
+      Pi
+        ( x,
+          CubeOf.mmap { map = (fun _ [ x ] -> term f x) } [ doms ],
+          CodCube.mmap { map = (fun _ [ x ] -> term f x) } [ cods ] )
+  | App (fn, args) -> App (term f fn, CubeOf.mmap { map = (fun _ [ x ] -> term f x) } [ args ])
+  | Constr (c, n, args) ->
+      Constr
+        (c, n, List.map (fun arg -> CubeOf.mmap { map = (fun _ [ x ] -> term f x) } [ arg ]) args)
+  | Act (tm, s) -> Act (term f tm, s)
+  | Let (x, v, body) -> Let (x, term f v, term f body)
+  | Lam (x, body) -> Lam (x, term f body)
+  | Struct (eta, dim, flds, energy) ->
+      Struct (eta, dim, Abwd.map (fun (x, l) -> (term f x, l)) flds, energy)
+  | Match { tm; dim; branches } ->
+      Match { tm = term f tm; dim; branches = Constr.Map.map (branch f) branches }
+  | Realize tm -> Realize (term f tm)
+  | Canonical can -> Canonical (canonical f can)
+
+and branch : type a n. (Compunit.t -> Compunit.t) -> (a, n) branch -> (a, n) branch =
+ fun f br ->
+  match br with
+  | Branch (ab, p, tm) -> Branch (ab, p, term f tm)
+  | Refute -> Refute
+
+and canonical : type a. (Compunit.t -> Compunit.t) -> a canonical -> a canonical =
+ fun f can ->
+  match can with
+  | Data { indices; constrs; discrete } ->
+      Data { indices; constrs = Abwd.map (dataconstr f) constrs; discrete }
+  | Codata { eta; opacity; dim; fields } ->
+      Codata { eta; opacity; dim; fields = Abwd.map (term f) fields }
+
+and dataconstr : type p i. (Compunit.t -> Compunit.t) -> (p, i) dataconstr -> (p, i) dataconstr =
+ fun f (Dataconstr { args; indices }) ->
+  Dataconstr { args; indices = Vec.mmap (fun [ x ] -> term f x) [ indices ] }
+
+and env : type a n b. (Compunit.t -> Compunit.t) -> (a, n, b) env -> (a, n, b) env =
+ fun f e ->
+  match e with
+  | Emp n -> Emp n
+  | Ext (e, xss) ->
+      Ext
+        ( env f e,
+          CubeOf.mmap
+            { map = (fun _ [ xs ] -> CubeOf.mmap { map = (fun _ [ x ] -> term f x) } [ xs ]) }
+            [ xss ] )

--- a/lib/core/meta.ml
+++ b/lib/core/meta.ml
@@ -125,5 +125,20 @@ module Map = struct
      fun key value map -> update key (fun _ -> Some value) map
 
     let remove : type b g. g Key.t -> b t -> b t = fun key map -> update key (fun _ -> None) map
+
+    type 'a mapper = { map : 'g. ('a, 'g) F.t -> ('a, 'g) F.t }
+
+    let map : type a. a mapper -> a t -> a t =
+     fun f m ->
+      Compunit.Map.map
+        (fun x ->
+          Map.map
+            {
+              map =
+                (fun { kinetic; potential } ->
+                  { kinetic = IntMap.map f.map kinetic; potential = IntMap.map f.map potential });
+            }
+            x)
+        m
   end
 end

--- a/lib/core/meta.ml
+++ b/lib/core/meta.ml
@@ -140,5 +140,24 @@ module Map = struct
             }
             x)
         m
+
+    let to_channel_unit :
+        type b. Out_channel.t -> Compunit.t -> b t -> Marshal.extern_flags list -> unit =
+     fun chan i map flags -> Marshal.to_channel chan (Compunit.Map.find_opt i map) flags
+
+    let from_channel_unit : type b. In_channel.t -> b mapper -> Compunit.t -> b t -> b t =
+     fun chan f i m ->
+      match (Marshal.from_channel chan : b Map.t option) with
+      | Some n ->
+          Compunit.Map.add i
+            (Map.map
+               {
+                 map =
+                   (fun { kinetic; potential } ->
+                     { kinetic = IntMap.map f.map kinetic; potential = IntMap.map f.map potential });
+               }
+               n)
+            m
+      | None -> m
   end
 end

--- a/lib/core/meta.ml
+++ b/lib/core/meta.ml
@@ -10,14 +10,20 @@ open Energy
 type sort = [ `Hole | `Def of string * string option ]
 
 (* A metavariable has an autonumber identity, like a constant.  It also stores its sort, and is parametrized by its checked context length and its energy (kinetic or potential). *)
-type ('b, 's) t = { number : int; sort : sort; len : 'b Dbwd.t; energy : 's energy }
+type ('b, 's) t = {
+  compunit : Compunit.t;
+  number : int;
+  sort : sort;
+  len : 'b Dbwd.t;
+  energy : 's energy;
+}
 
-let counter = ref (-1)
+let counters = Compunit.IntArray.make_basic ()
 
-let make : type b s. sort -> b Dbwd.t -> s energy -> (b, s) t =
- fun sort len energy ->
-  counter := !counter + 1;
-  { number = !counter; sort; len; energy }
+let make : type b s. Compunit.t -> sort -> b Dbwd.t -> s energy -> (b, s) t =
+ fun compunit sort len energy ->
+  let number = Compunit.IntArray.inc counters compunit in
+  { compunit; number; sort; len; energy }
 
 let name : type b s. (b, s) t -> string =
  fun x ->
@@ -56,15 +62,17 @@ module Map = struct
         kinetic : ('b, 'g * kinetic) F.t IntMap.t;
         potential : ('b, 'g * potential) F.t IntMap.t;
       }
+
+      let empty : ('b, 'g) t = { kinetic = IntMap.empty; potential = IntMap.empty }
     end
 
     module Map = DbwdMap.Make (EIMap)
 
-    type 'b t = 'b Map.t
+    type 'b t = 'b Map.t Compunit.Map.t
 
     open Monad.Ops (Monad.Maybe)
 
-    let empty : type b. b t = Map.empty
+    let empty : type b. b t = Compunit.Map.empty
 
     let find_opt : type b g. g Key.t -> b t -> (b, g) F.t option =
      fun key map ->
@@ -74,23 +82,9 @@ module Map = struct
         | Kinetic -> IntMap.find_opt i eimap.kinetic
         | Potential -> IntMap.find_opt i eimap.potential in
       let (MetaKey m) = key in
-      let* eimap = Map.find_opt m.len map in
-      go m.energy m.number eimap
-
-    let add : type b g. g Key.t -> (b, g) F.t -> b t -> b t =
-     fun key value map ->
-      let go : type b s g. s energy -> int -> (b, g * s) F.t -> (b, g) EIMap.t -> (b, g) EIMap.t =
-       fun s i value eimap ->
-        match s with
-        | Kinetic -> { eimap with kinetic = IntMap.add i value eimap.kinetic }
-        | Potential -> { eimap with potential = IntMap.add i value eimap.potential } in
-      let (MetaKey m) = key in
-      Map.update m.len
-        (function
-          | Some eimap -> Some (go m.energy m.number value eimap)
-          | None ->
-              Some (go m.energy m.number value { kinetic = IntMap.empty; potential = IntMap.empty }))
-        map
+      let* map = Compunit.Map.find_opt m.compunit map in
+      let* map = Map.find_opt m.len map in
+      go m.energy m.number map
 
     let update : type b g. g Key.t -> ((b, g) F.t option -> (b, g) F.t option) -> b t -> b t =
      fun key f map ->
@@ -106,25 +100,27 @@ module Map = struct
         | Kinetic -> { eimap with kinetic = IntMap.update i f eimap.kinetic }
         | Potential -> { eimap with potential = IntMap.update i f eimap.potential } in
       let (MetaKey m) = key in
-      Map.update m.len
+      Compunit.Map.update m.compunit
         (function
-          | Some eimap -> Some (go m.energy m.number f eimap)
+          | Some map ->
+              Some
+                (Map.update m.len
+                   (function
+                     | Some map -> Some (go m.energy m.number f map)
+                     | None -> Some (go m.energy m.number f EIMap.empty))
+                   map)
           | None ->
-              Some (go m.energy m.number f { kinetic = IntMap.empty; potential = IntMap.empty }))
+              Some
+                (Map.update m.len
+                   (function
+                     | Some map -> Some (go m.energy m.number f map)
+                     | None -> Some (go m.energy m.number f EIMap.empty))
+                   Map.empty))
         map
 
-    let remove : type b g. g Key.t -> b t -> b t =
-     fun key map ->
-      let go : type b s g. s energy -> int -> (b, g) EIMap.t -> (b, g) EIMap.t =
-       fun s i eimap ->
-        match s with
-        | Kinetic -> { eimap with kinetic = IntMap.remove i eimap.kinetic }
-        | Potential -> { eimap with potential = IntMap.remove i eimap.potential } in
-      let (MetaKey m) = key in
-      Map.update m.len
-        (function
-          | Some eimap -> Some (go m.energy m.number eimap)
-          | None -> None)
-        map
+    let add : type b g. g Key.t -> (b, g) F.t -> b t -> b t =
+     fun key value map -> update key (fun _ -> Some value) map
+
+    let remove : type b g. g Key.t -> b t -> b t = fun key map -> update key (fun _ -> None) map
   end
 end

--- a/lib/core/meta.ml
+++ b/lib/core/meta.ml
@@ -25,6 +25,9 @@ let make : type b s. Compunit.t -> sort -> b Dbwd.t -> s energy -> (b, s) t =
   let number = Compunit.IntArray.inc counters compunit in
   { compunit; number; sort; len; energy }
 
+let remake : type b s. (Compunit.t -> Compunit.t) -> (b, s) t -> (b, s) t =
+ fun f m -> { m with compunit = f m.compunit }
+
 let name : type b s. (b, s) t -> string =
  fun x ->
   match x.sort with

--- a/lib/core/meta.mli
+++ b/lib/core/meta.mli
@@ -6,7 +6,7 @@ open Energy
 type sort = [ `Hole | `Def of string * string option ]
 type ('b, 's) t
 
-val make : sort -> 'b Dbwd.t -> 's energy -> ('b, 's) t
+val make : Compunit.t -> sort -> 'b Dbwd.t -> 's energy -> ('b, 's) t
 val name : ('b, 's) t -> string
 val compare : ('b1, 's1) t -> ('b2, 's2) t -> ('b1 * 's1, 'b2 * 's2) Eq.compare
 

--- a/lib/core/meta.mli
+++ b/lib/core/meta.mli
@@ -17,4 +17,13 @@ module Key : sig
   type 'b t = 'b key
 end
 
-module Map : MAP_MAKER with module Key = Key
+module Map : sig
+  module Key = Key
+
+  module Make : functor (F : Fam2) -> sig
+    include MAP with module Key := Key and module F := F
+
+    val to_channel_unit : Out_channel.t -> Compunit.t -> 'b t -> Marshal.extern_flags list -> unit
+    val from_channel_unit : In_channel.t -> 'b mapper -> Compunit.t -> 'b t -> 'b t
+  end
+end

--- a/lib/core/meta.mli
+++ b/lib/core/meta.mli
@@ -7,6 +7,7 @@ type sort = [ `Hole | `Def of string * string option ]
 type ('b, 's) t
 
 val make : Compunit.t -> sort -> 'b Dbwd.t -> 's energy -> ('b, 's) t
+val remake : (Compunit.t -> Compunit.t) -> ('b, 's) t -> ('b, 's) t
 val name : ('b, 's) t -> string
 val compare : ('b1, 's1) t -> ('b2, 's2) t -> ('b1 * 's1, 'b2 * 's2) Eq.compare
 

--- a/lib/core/readback.ml
+++ b/lib/core/readback.ml
@@ -174,8 +174,7 @@ and readback_head : type a z. (z, a) Ctx.t -> head -> (a, kinetic) term =
       Act (Const name, deg)
   | Meta { meta; env; ins } ->
       let perm = deg_of_ins ins (plus_of_ins ins) in
-      let (Metadef { termctx; _ }) =
-        Global.find_meta_opt meta <|> Undefined_metavariable (PMeta meta) in
+      let (Metadef { termctx; _ }) = Global.find_meta meta in
       Act (MetaEnv (meta, readback_env ctx env termctx), perm)
 
 and readback_at_tel :

--- a/lib/core/reporter.ml
+++ b/lib/core/reporter.ml
@@ -142,8 +142,9 @@ module Code = struct
     | Type_expected : string -> t
     | Circular_import : string list -> t
     | Loading_file : string -> t
-    | File_loaded : string -> t
+    | File_loaded : string * [ `Compiled | `Source ] -> t
     | Library_has_extension : string -> t
+    | Invalid_filename : string -> t
 
   (** The default severity of messages with a particular message code. *)
   let default_severity : t -> Asai.Diagnostic.severity = function
@@ -251,6 +252,7 @@ module Code = struct
     | Loading_file _ -> Info
     | File_loaded _ -> Info
     | Library_has_extension _ -> Warning
+    | Invalid_filename _ -> Error
 
   (** A short, concise, ideally Google-able string representation for each message code. *)
   let short_code : t -> string = function
@@ -371,6 +373,7 @@ module Code = struct
     (* import *)
     | Circular_import _ -> "E2300"
     | Library_has_extension _ -> "W2301"
+    | Invalid_filename _ -> "E2302"
     (* Interactive proof *)
     | Open_holes -> "E3000"
     (* Command progress and success *)
@@ -632,8 +635,10 @@ module Code = struct
              pp_print_string)
           files
     | Loading_file file -> textf "loading file: %s" file
-    | File_loaded file -> textf "file loaded: %s" file
+    | File_loaded (file, `Compiled) -> textf "file loaded: %s (compiled)" file
+    | File_loaded (file, `Source) -> textf "file loaded: %s (source)" file
     | Library_has_extension file -> textf "putative library name '%s' has extension" file
+    | Invalid_filename file -> textf "filename '%s' does not have 'ny' extension" file
 end
 
 include Asai.StructuredReporter.Make (Code)

--- a/lib/core/reporter.ml
+++ b/lib/core/reporter.ml
@@ -146,6 +146,7 @@ module Code = struct
     | Library_has_extension : string -> t
     | Invalid_filename : string -> t
     | Incompatible_flags : string * string -> t
+    | Actions_in_compiled_file : string -> t
 
   (** The default severity of messages with a particular message code. *)
   let default_severity : t -> Asai.Diagnostic.severity = function
@@ -255,6 +256,7 @@ module Code = struct
     | Library_has_extension _ -> Warning
     | Invalid_filename _ -> Error
     | Incompatible_flags _ -> Warning
+    | Actions_in_compiled_file _ -> Warning
 
   (** A short, concise, ideally Google-able string representation for each message code. *)
   let short_code : t -> string = function
@@ -377,6 +379,8 @@ module Code = struct
     | Library_has_extension _ -> "W2301"
     | Invalid_filename _ -> "E2302"
     | Incompatible_flags _ -> "W2303"
+    (* echo *)
+    | Actions_in_compiled_file _ -> "W2400"
     (* Interactive proof *)
     | Open_holes -> "E3000"
     (* Command progress and success *)
@@ -644,6 +648,8 @@ module Code = struct
     | Invalid_filename file -> textf "filename '%s' does not have 'ny' extension" file
     | Incompatible_flags (file, flags) ->
         textf "file '%s' was compiled with incompatible flags %s, recompiling" file flags
+    | Actions_in_compiled_file file ->
+        textf "not re-executing 'echo' commands when loading compiled file %s" file
 end
 
 include Asai.StructuredReporter.Make (Code)

--- a/lib/core/reporter.ml
+++ b/lib/core/reporter.ml
@@ -145,6 +145,7 @@ module Code = struct
     | File_loaded : string * [ `Compiled | `Source ] -> t
     | Library_has_extension : string -> t
     | Invalid_filename : string -> t
+    | Incompatible_flags : string * string -> t
 
   (** The default severity of messages with a particular message code. *)
   let default_severity : t -> Asai.Diagnostic.severity = function
@@ -253,6 +254,7 @@ module Code = struct
     | File_loaded _ -> Info
     | Library_has_extension _ -> Warning
     | Invalid_filename _ -> Error
+    | Incompatible_flags _ -> Warning
 
   (** A short, concise, ideally Google-able string representation for each message code. *)
   let short_code : t -> string = function
@@ -374,6 +376,7 @@ module Code = struct
     | Circular_import _ -> "E2300"
     | Library_has_extension _ -> "W2301"
     | Invalid_filename _ -> "E2302"
+    | Incompatible_flags _ -> "W2303"
     (* Interactive proof *)
     | Open_holes -> "E3000"
     (* Command progress and success *)
@@ -639,6 +642,8 @@ module Code = struct
     | File_loaded (file, `Source) -> textf "file loaded: %s (source)" file
     | Library_has_extension file -> textf "putative library name '%s' has extension" file
     | Invalid_filename file -> textf "filename '%s' does not have 'ny' extension" file
+    | Incompatible_flags (file, flags) ->
+        textf "file '%s' was compiled with incompatible flags %s, recompiling" file flags
 end
 
 include Asai.StructuredReporter.Make (Code)

--- a/lib/core/syntax.ml
+++ b/lib/core/syntax.ml
@@ -679,7 +679,7 @@ and universe_ty : type n. n D.t -> kinetic value =
 (* Whether the -discreteness flag is on globally *)
 module Discreteness = Algaeff.Reader.Make (Bool)
 
-(* Which constants currently being defined are discrete.  Currently (June 2024) at most a singleton, since mutual discrete families are disallowed. *)
+(* Which constants currently being defined are discrete.  The *keys* of the map are *all* the constants currently being defined, while the *values* of the map indicate whether we have *already decided* that that constant is discrete.  *)
 module Discrete = Algaeff.State.Make (struct
   type t = bool Constant.Map.t
 end)

--- a/lib/parser/command.ml
+++ b/lib/parser/command.ml
@@ -303,10 +303,12 @@ let check_constant_name name =
       fatal ~severity:Asai.Diagnostic.Error (Name_already_defined (String.concat "." name))
   | None -> ()
 
-let execute : Command.t -> unit = function
+let execute : Command.t -> unit =
+ fun cmd ->
+  match cmd with
   | Axiom { name; parameters; ty = Term ty; _ } ->
       check_constant_name name;
-      let const = Scope.define name in
+      let const = Scope.define (Compunit.Current.read ()) name in
       Reporter.try_with ~fatal:(fun d ->
           Scope.modify_visible (Yuujinchou.Language.except name);
           Scope.modify_export (Yuujinchou.Language.except name);
@@ -319,7 +321,7 @@ let execute : Command.t -> unit = function
         Mlist.pmap
           (fun [ d ] ->
             check_constant_name d.name;
-            let c = Scope.define d.name in
+            let c = Scope.define (Compunit.Current.read ()) d.name in
             [ d.name; (c, d) ])
           [ defs ] (Cons (Cons Nil)) in
       Reporter.try_with ~fatal:(fun d ->

--- a/lib/parser/command.ml
+++ b/lib/parser/command.ml
@@ -414,7 +414,7 @@ let execute : Command.t -> unit =
   | Import { file; _ } ->
       if FilePath.check_extension file "ny" then emit (Library_has_extension file);
       let file = FilePath.add_extension file "ny" in
-      let trie = Units.get (`File file) false in
+      let trie = Units.get_file file in
       Scope.import_subtree ([], trie)
   | Quit _ -> fatal (Quit None)
   | Bof _ -> ()

--- a/lib/parser/command.ml
+++ b/lib/parser/command.ml
@@ -351,6 +351,7 @@ let execute : Command.t -> unit =
       Core.Command.execute (Def defs)
   | Echo { tm = Term tm; _ } -> (
       let rtm = process Emp tm in
+      Units.Loading.modify (fun s -> { s with actions = true });
       match rtm.value with
       | Synth stm ->
           Readback.Display.run ~env:true @@ fun () ->

--- a/lib/parser/notation.ml
+++ b/lib/parser/notation.ml
@@ -132,7 +132,7 @@ and (_, _, _, _) parse =
       ('lt, 'ls, No.plus_omega, No.strict) parse located option * string * Whitespace.t list
       -> ('lt, 'ls, 'rt, 'rs) parse
 
-(* A postproccesing function has to be polymorphic over the length of the context so as to produce intrinsically well-scoped terms.  Thus, we have to wrap it as a field of a record (or object).  The whitespace argument should be ignored, but we include it so that complicated notation processing functions can be shared between the processor and the printer. *)
+(* A postproccesing function has to be polymorphic over the length of the context so as to produce intrinsically well-scoped terms.  Thus, we have to wrap it as a field of a record (or object).  The whitespace argument is often ignored, but it allows complicated notation processing functions to be shared between the processor and the printer, and sometimes the processing functions need to inspect the sequence of tokens which is stored with the whitespace. *)
 and processor = {
   process :
     'n.
@@ -441,3 +441,15 @@ let merge :
     type t1 t2 s1 s2.
     (t2, s2, t1, s1) Interval.subset -> (t1, s1) entry -> (t2, s2) entry -> (t1, s1) entry =
  fun sub xs ys -> merge_tmap sub xs ys
+
+(* Printable notations *)
+
+(* TODO: Rename these.  "head"?  And think about what files they should be in. *)
+type printkey = [ `Constant of Core.Constant.t | `Constr of Core.Constr.t * int ]
+
+type permuted_notation = {
+  key : printkey;
+  notn : Notation.t;
+  pat_vars : string list;
+  val_vars : string list;
+}

--- a/lib/parser/notation.mli
+++ b/lib/parser/notation.mli
@@ -168,3 +168,12 @@ val lower : ('t2, 's2, 't1, 's1) Interval.subset -> ('t2, 's2) entry -> ('t1, 's
 
 val merge :
   ('t2, 's2, 't1, 's1) Interval.subset -> ('t1, 's1) entry -> ('t2, 's2) entry -> ('t1, 's1) entry
+
+type printkey = [ `Constant of Core.Constant.t | `Constr of Core.Constr.t * int ]
+
+type permuted_notation = {
+  key : printkey;
+  notn : Notation.t;
+  pat_vars : string list;
+  val_vars : string list;
+}

--- a/lib/parser/pi.ml
+++ b/lib/parser/pi.ml
@@ -6,7 +6,7 @@ open Check
 open Notation
 open Postprocess
 
-let const = Constant.make ()
+let const = Constant.make Compunit.basic
 
 let install trie =
   let ctx = Ctx.empty in

--- a/lib/parser/scope.ml
+++ b/lib/parser/scope.ml
@@ -50,7 +50,7 @@ let name_of c =
   | None -> [ "_UNNAMED_CONSTANT" ]
 
 (* Create a new Constant.t and define a name to equal it. *)
-let define name =
-  let c = Constant.make () in
+let define compunit name =
+  let c = Constant.make compunit in
   include_singleton (name, (`Constant c, ()));
   c

--- a/lib/parser/scope.ml
+++ b/lib/parser/scope.ml
@@ -1,10 +1,10 @@
 open Core
-open User
+open Notation
 module Trie = Yuujinchou.Trie
 
 (* Parameter module for Yuujinchou *)
 module P = struct
-  type data = [ `Constant of Constant.t | `Notation of PrintKey.t * permuted_notation ]
+  type data = [ `Constant of Constant.t | `Notation of User.user_notation * permuted_notation ]
 
   (* Currently we have no nontrivial tags, hooks, or contexts. *)
   type tag = unit

--- a/lib/parser/units.ml
+++ b/lib/parser/units.ml
@@ -34,7 +34,7 @@ end
 
 module Loading = Algaeff.State.Make (Loadstate)
 
-(* This is how the executable supplies a callback that loads files.  We take care of calling that function as needed and caching the results in a hashtable for future calls.  We also compute the result of combining all the units, but lazily since we'll only need it if there are command-line strings, stdin, or interactive.  The first argument is a default initial visible namespace, which can be overridden. *)
+(* This is how the executable supplies a callback that loads files.  It will always be passed a reduced absolute filename.  We take care of calling that function as needed and caching the results in a hashtable for future calls.  We also compute the result of combining all the units, but lazily since we'll only need it if there are command-line strings, stdin, or interactive.  The first argument is a default initial visible namespace, which can be overridden. *)
 let with_compile :
     type a. trie -> (trie -> Asai.Range.source -> trie * Compunit.t) -> (unit -> a) -> a =
  fun init compute f ->
@@ -88,7 +88,7 @@ let with_compile :
                                 imports = Emp;
                               }
                           @@ fun () ->
-                          go @@ fun () -> compute start source in
+                          go @@ fun () -> compute start (`File file) in
                         if not top then emit (File_loaded file);
                         Hashtbl.add table file (trie, compunit, top);
                         if top then add_to_all trie;

--- a/lib/parser/units.ml
+++ b/lib/parser/units.ml
@@ -3,6 +3,8 @@ open Core
 open Reporter
 module Trie = Yuujinchou.Trie
 
+(* Compilation units (i.e. files).  This module is called "Units" because "Unit" is the module "struct type t = unit end".  (-: *)
+
 type trie = (Scope.P.data, Scope.P.tag) Trie.t
 
 (* For separate compilation, we expect the executable to know how to load compilation units and compute their resulting export namespaces.  We wrap this in an effect, so that it can also be invoked *during* the loading of some other unit, with a 'require' command.  We also include an effect that combines all the top-level namespaces (i.e. those not only loaded "transitively" through require) so far into a single one.  The boolean argument to load_unit indicates whether it is being invoked from top level, and the namespace is a starting visible one to override the default.  *)
@@ -19,6 +21,8 @@ let load ?init source =
   ()
 
 let all () = Effect.perform All_units
+
+(* We store effectually the current directory and a list of all files whose loading is currently in progress, i.e. the path of imports that led us to the current file.  The former is used for making filenames absolute; the latter is used to check for circular imports. *)
 
 module Loadstate = struct
   type t = { cwd : FilePath.filename; parents : FilePath.filename Bwd.t }

--- a/lib/parser/units.ml
+++ b/lib/parser/units.ml
@@ -115,7 +115,7 @@ let run ~(init_visible : trie) f =
     (Seq.fold_left
        (fun state (_, (data, _)) ->
          match data with
-         | `Notation (key, notn) -> state |> State.add_with_print key notn
+         | `Notation (user, _) -> fst (State.add_user user state)
          | _ -> state)
        !Builtins.builtins
        (Trie.to_seq (Trie.find_subtree [ "notation" ] init_visible)))

--- a/lib/parser/unparse.ml
+++ b/lib/parser/unparse.ml
@@ -16,7 +16,7 @@ module StringMap = Map.Make (String)
 (* If the head of an application spine is a constant or constructor, and it has an associated notation, and there are enough of the supplied arguments to instantiate the notation, split off that many arguments and return the notation, those arguments permuted to match the order of the pattern variables in the notation, and the rest. *)
 let get_notation head args =
   let open Monad.Ops (Monad.Maybe) in
-  let* { notn; pat_vars; val_vars } =
+  let* { key = _; notn; pat_vars; val_vars } =
     match head with
     | `Term (Const c) -> State.Current.unparse (`Constant c)
     | `Constr c -> State.Current.unparse (`Constr (c, Bwd.length args))

--- a/lib/parser/user.ml
+++ b/lib/parser/user.ml
@@ -1,13 +1,54 @@
+open Core
+open Reporter
 open Notation
 
 (* User notations *)
 
-module PrintKey = struct
-  type t = [ `Constant of Core.Constant.t | `Constr of Core.Constr.t * int ]
+type pattern =
+  [ `Op of Token.t * space * Whitespace.t list
+  | `Var of string * space * Whitespace.t list
+  | `Ellipsis of Whitespace.t list ]
+  list
 
-  let compare : t -> t -> int = compare
-end
+let user_tree :
+    type left tight right.
+    (left, tight, right) fixity ->
+    (left, tight, right) notation ->
+    pattern ->
+    (left, tight) notation_entry =
+ fun fixity notn pattern ->
+  let left, _, _ = fixprops fixity in
+  let rec user_tree pattern n =
+    match (pattern, left) with
+    | [], Closed -> n
+    | [], Open _ -> fatal (Anomaly "pattern doesn't match deduced fixity")
+    | [ `Var _ ], Open _ -> n
+    | [ `Var _ ], Closed -> fatal (Anomaly "pattern doesn't match deduced fixity")
+    | `Op (tok, _, _) :: pat_vars, _ -> op tok (user_tree pat_vars n)
+    | `Var _ :: `Op (tok, _, _) :: pat_vars, _ -> term tok (user_tree pat_vars n)
+    | `Var _ :: `Var _ :: _, _ -> fatal Missing_notation_symbol
+    | `Var _ :: `Ellipsis _ :: _, _ -> fatal (Unimplemented "internal ellipses in notation")
+    | `Ellipsis _ :: _, _ -> fatal (Unimplemented "internal ellipses in notation") in
+  match (pattern, left) with
+  | [], _ -> fatal (Anomaly "empty pattern")
+  | `Op (tok, _, _) :: pat_vars, Closed ->
+      Closed_entry (eop tok (user_tree pat_vars (Done_closed notn)))
+  | `Var _ :: `Op (tok, _, _) :: pat_vars, Open _ ->
+      Open_entry (eop tok (user_tree pat_vars (done_open notn)))
+  | `Var _ :: _, Closed | `Op _ :: _, Open _ ->
+      fatal (Anomaly "pattern doesn't match deduced fixity")
+  | `Var _ :: `Ellipsis _ :: _, _ | `Ellipsis _ :: _, _ ->
+      fatal (Unimplemented "internal ellipses in notation")
+  | `Var _ :: `Var _ :: _, _ -> fatal Missing_notation_symbol
+  | [ `Var _ ], _ -> fatal Zero_notation_symbols
 
-module PrintMap = Map.Make (PrintKey)
-
-type permuted_notation = { notn : Notation.t; pat_vars : string list; val_vars : string list }
+type user_notation =
+  | User : {
+      name : string;
+      fixity : ('left, 'tight, 'right) fixity;
+      (* The space tag on the last element is ignored. *)
+      pattern : pattern;
+      key : printkey;
+      val_vars : string list;
+    }
+      -> user_notation

--- a/lib/util/nmap.ml
+++ b/lib/util/nmap.ml
@@ -47,6 +47,14 @@ module Make (F : Fam2) : MAP with module Key := N and module F := F = struct
           match mn with
           | Zero -> Entry (None, xs)
           | Suc mn -> Entry (x, remove mn xs))
+
+    type 'a mapper = { map : 'g. ('a, 'g) F.t -> ('a, 'g) F.t }
+
+    let rec map : type a m. a mapper -> (a, m) map -> (a, m) map =
+     fun f m ->
+      match m with
+      | Empty -> Empty
+      | Entry (x, xs) -> Entry (Option.map f.map x, map f xs)
   end
 
   let find_opt : type b m n. n N.t -> (b, N.zero) map -> (b, n) F.t option =
@@ -70,6 +78,11 @@ module Make (F : Fam2) : MAP with module Key := N and module F := F = struct
    fun n map ->
     let (Of_bwn (_, mn)) = Fwn.of_bwn n in
     Internal.remove mn map
+
+  type 'a mapper = { map : 'g. ('a, 'g) F.t -> ('a, 'g) F.t }
+
+  let map : type b. b mapper -> (b, N.zero) map -> (b, N.zero) map =
+   fun f m -> Internal.map { map = f.map } m
 
   type 'b t = ('b, N.zero) map
 

--- a/lib/util/no.ml
+++ b/lib/util/no.ml
@@ -548,6 +548,25 @@ module Map = struct
       | Minus_omega -> { map with minus_omega = f map.minus_omega }
       | Plus_omega -> { map with plus_omega = f map.plus_omega }
 
+    (* 'map' applies a function to all entries in the map. *)
+
+    type 'a mapper = { map : 'g. ('a, 'g) F.t -> ('a, 'g) F.t }
+
+    let rec fin_map : type x a. x mapper -> (x, a) fin_t -> (x, a) fin_t =
+     fun f m ->
+      match m with
+      | Emp -> Emp
+      | Node (None, mmap, pmap) -> Node (None, fin_map f mmap, fin_map f pmap)
+      | Node (Some (ab, z), mmap, pmap) -> Node (Some (ab, f.map z), fin_map f mmap, fin_map f pmap)
+
+    let map : type x a. x mapper -> x t -> x t =
+     fun f { fin; minus_omega; plus_omega } ->
+      {
+        fin = fin_map f fin;
+        minus_omega = Option.map f.map minus_omega;
+        plus_omega = Option.map f.map plus_omega;
+      }
+
     (* 'map_compare' applies one of three polymorphic function to all elements of the map, based on whether their index is less than, greater than, or equal to some specified number, passing a witness of inequality if relevant.  This requires a record type to hold the polymorphic mapper arguments, as well as several helper functions.  *)
 
     type ('x, 'b) map_compare = {

--- a/lib/util/signatures.ml
+++ b/lib/util/signatures.ml
@@ -27,6 +27,12 @@ module type MAP = sig
   val add : 'g Key.t -> ('b, 'g) F.t -> 'b t -> 'b t
   val update : 'g Key.t -> (('b, 'g) F.t option -> ('b, 'g) F.t option) -> 'b t -> 'b t
   val remove : 'g Key.t -> 'b t -> 'b t
+
+  (* Mapping over intrinsically well-typed maps is complicated.  The mapping function has to be able to deal with any key, hence any parametrizing type for that key, so we have to wrap it up in a record with a polymorphic field.  Moreover, because some implementations of intrinsically well-typed maps shift the key parameter into a factor of the ambient parameter, there are issues with trying to change the ambient parameter.  Fortunately, for current applications, it suffices to keep that parameter the same. *)
+
+  type 'a mapper = { map : 'g. ('a, 'g) F.t -> ('a, 'g) F.t }
+
+  val map : 'a mapper -> 'a t -> 'a t
 end
 
 module type MAP_MAKER = sig

--- a/test/black/1tuples.t
+++ b/test/black/1tuples.t
@@ -28,7 +28,7 @@
    ￮ Constant wa3 defined
   
    ￫ error[E0401]
-   ￭ wrap.ny
+   ￭ $TESTCASE_ROOT/wrap.ny
    7 | def wa4 : wrapA := (a)
      ^ term synthesized type A but is being checked against type wrapA
   

--- a/test/black/axiomK.t
+++ b/test/black/axiomK.t
@@ -5,7 +5,7 @@ Using the Martin-Löf "Jdentity type" as an indexed datatype, we can try to prov
   > | rfl. : Jd A a a
   > ]
 
-  $ narya jd.ny -v -e 'def USIP (A:Type) (a:A) (e:Jd A a a) : Jd (Jd A a a) e rfl. := match e [ rfl. |-> rfl. ]'
+  $ narya -source-only jd.ny -v -e 'def USIP (A:Type) (a:A) (e:Jd A a a) : Jd (Jd A a a) e rfl. := match e [ rfl. |-> rfl. ]'
    ￫ info[I0000]
    ￮ Constant Jd defined
   
@@ -25,7 +25,7 @@ Using the Martin-Löf "Jdentity type" as an indexed datatype, we can try to prov
   
   [1]
 
-  $ narya jd.ny -v -e 'def K (A:Type) (a:A) (P : Jd A a a -> Type) (p : P rfl.) (e : Jd A a a) : P e := match e [ rfl. |-> p ]'
+  $ narya -source-only jd.ny -v -e 'def K (A:Type) (a:A) (P : Jd A a a -> Type) (p : P rfl.) (e : Jd A a a) : P e := match e [ rfl. |-> p ]'
    ￫ info[I0000]
    ￮ Constant Jd defined
   
@@ -43,7 +43,7 @@ Using the Martin-Löf "Jdentity type" as an indexed datatype, we can try to prov
 
 This "weak K" is mentioned in the "Pattern-matching without K" paper as justifying their second "injectivity" restriction on unification.
 
-  $ narya jd.ny -v -e 'def weakK (A:Type) (a:A) (P : Jd (Jd A a a) rfl. rfl. -> Type) (p : P rfl.) (e : Jd (Jd A a a) rfl. rfl.) : P e := match e [ rfl. |-> p ]'
+  $ narya -source-only jd.ny -v -e 'def weakK (A:Type) (a:A) (P : Jd (Jd A a a) rfl. rfl. -> Type) (p : P rfl.) (e : Jd (Jd A a a) rfl. rfl.) : P e := match e [ rfl. |-> p ]'
    ￫ info[I0000]
    ￮ Constant Jd defined
   
@@ -67,7 +67,7 @@ The following indexed datatype appears in Agda bug #1025.
   > axiom a : A
   > def Foo : Jd A a a → Type ≔ data [ foo. : Foo rfl. ]
 
-  $ narya jd.ny foo.ny -v -e 'def test (e : Jd A a a) (f : Foo e) (i : Jd (Foo e) f f) : Jd (Jd (Foo e) f f) i rfl. ≔ match f [ foo. ↦ match i [ rfl. ↦ rfl. ]]'
+  $ narya -source-only jd.ny foo.ny -v -e 'def test (e : Jd A a a) (f : Foo e) (i : Jd (Foo e) f f) : Jd (Jd (Foo e) f f) i rfl. ≔ match f [ foo. ↦ match i [ rfl. ↦ rfl. ]]'
    ￫ info[I0000]
    ￮ Constant Jd defined
   
@@ -104,7 +104,7 @@ The heterogeneous Jdentity type also figures in some inconsistencies, such as Ag
   > def D : Bool → Type ≔ data [ x. : D true. | y. : D false. ]
   > def ∅ : Type ≔ data []
 
-  $ narya hjd.ny -v -e 'def notpdf (u : D false.) (e : Hd (D false.) u (D true.) x.) : ∅ ≔ match e [ ]'
+  $ narya -source-only hjd.ny -v -e 'def notpdf (u : D false.) (e : Hd (D false.) u (D true.) x.) : ∅ ≔ match e [ ]'
    ￫ info[I0000]
    ￮ Constant Hd defined
   

--- a/test/black/compile.t
+++ b/test/black/compile.t
@@ -262,3 +262,19 @@ Dimensions work in files loaded from source
   a2
     : refl A a0 a1
   
+Echos are not re-executed in compiled files
+
+  $ cat >echo.ny <<EOF
+  > axiom A:Type
+  > echo A
+  > EOF
+
+  $ narya echo.ny
+  A
+    : Type
+  
+
+  $ narya echo.ny
+   ￫ warning[W2400]
+   ￮ not re-executing 'echo' commands when loading compiled file $TESTCASE_ROOT/echo.nyo
+  

--- a/test/black/compile.t
+++ b/test/black/compile.t
@@ -1,0 +1,180 @@
+Import compiled files
+
+  $ cat >one.ny <<EOF
+  > axiom A : Type
+  > EOF
+
+  $ cat >two.ny <<EOF
+  > import "one"
+  > axiom a0 : A
+  > EOF
+
+  $ narya one.ny
+
+  $ narya -v two.ny
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/one.ny (compiled)
+  
+   ￫ info[I0001]
+   ￮ Axiom a0 assumed
+  
+
+Requiring a file multiple times
+
+  $ cat >three.ny <<EOF
+  > import "one"
+  > axiom a1 : A
+  > EOF
+
+  $ narya three.ny
+
+  $ cat >four.ny <<EOF
+  > import "one"
+  > import "two"
+  > import "three"
+  > axiom a2 : Id A a0 a1
+
+  $ narya -v four.ny
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/one.ny (compiled)
+  
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/two.ny (compiled)
+  
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/three.ny (compiled)
+  
+   ￫ info[I0001]
+   ￮ Axiom a2 assumed
+  
+
+Circular dependency
+
+  $ cat >foo.ny <<EOF
+  > import "bar"
+  > EOF
+
+  $ cat >bar.ny <<EOF
+  > import "foo"
+  > EOF
+
+  $ narya foo.ny
+   ￫ error[E2300]
+   ￮ circular imports:
+     $TESTCASE_ROOT/foo.ny
+       imports $TESTCASE_ROOT/bar.ny
+       imports $TESTCASE_ROOT/foo.ny
+  
+  [1]
+
+Import is relative to the file's directory
+
+  $ mkdir subdir
+
+  $ cat >subdir/one.ny <<EOF
+  > axiom A:Type
+  > EOF
+
+  $ cat >subdir/two.ny <<EOF
+  > import "one"
+  > axiom a : A
+  > EOF
+
+  $ narya subdir/one.ny
+
+  $ narya subdir/two.ny
+
+  $ narya -v -e 'import "subdir/two"'
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/subdir/one.ny (compiled)
+  
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/subdir/two.ny (compiled)
+  
+
+A file isn't loaded twice even if referred to in different ways
+
+  $ narya -v subdir/one.ny -e 'import "subdir/two"'
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/subdir/two.ny (compiled)
+  
+
+Notations are used from explicitly imported files, but not transitively.
+
+  $ cat >n1.ny <<EOF
+  > axiom A:Type
+  > axiom f : A -> A -> A
+  > axiom a:A
+  > EOF
+
+  $ cat >n2.ny <<EOF
+  > import "n1"
+  > notation 0 f : x "&" y := f x y
+  > EOF
+
+  $ cat >n3.ny <<EOF
+  > import "n1"
+  > import "n2"
+  > notation 0 f2 : x "%" y := f x y
+  > EOF
+
+  $ narya n1.ny
+
+  $ narya n2.ny
+
+  $ narya n1.ny n3.ny -e 'echo a % a'
+  a % a
+    : A
+  
+
+  $ narya n1.ny n3.ny -e 'echo a & a'
+  a
+    : A
+  
+   ￫ error[E0200]
+   ￭ command-line exec string
+   1 | echo a & a
+     ^ parse error
+  
+  [1]
+
+Quitting in imports quits only that file
+
+  $ cat >qone.ny <<EOF
+  > axiom A : Type
+  > quit
+  > axiom B : Type
+  > EOF
+
+  $ narya qone.ny
+
+  $ cat >qtwo.ny <<EOF
+  > import "qone"
+  > axiom a0 : A
+  > EOF
+
+  $ narya -v qtwo.ny
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/qone.ny (compiled)
+  
+   ￫ info[I0001]
+   ￮ Axiom a0 assumed
+  
+Dimensions work in files loaded from source
+
+  $ cat >dim.ny <<EOF
+  > axiom A:Type
+  > axiom a0:A
+  > axiom a1:A
+  > axiom a2 : Id A a0 a1
+  > EOF
+
+  $ narya dim.ny
+
+  $ narya -v -e 'import "dim" echo a2'
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/dim.ny (compiled)
+  
+  a2
+    : refl A a0 a1
+  

--- a/test/black/compile.t
+++ b/test/black/compile.t
@@ -19,6 +19,54 @@ Import compiled files
    ￮ Axiom a0 assumed
   
 
+Modified files are recompiled
+
+  $ touch one.ny
+
+  $ narya -v two.ny
+   ￫ info[I0003]
+   ￮ loading file: $TESTCASE_ROOT/one.ny
+  
+   ￫ info[I0001]
+   ￮ Axiom A assumed
+  
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/one.ny (source)
+  
+   ￫ info[I0001]
+   ￮ Axiom a0 assumed
+  
+
+Files are recompiled if the flags change
+
+  $ narya -dtt -v two.ny
+   ￫ warning[W2303]
+   ￮ file '$TESTCASE_ROOT/two.ny' was compiled with incompatible flags -arity 2 -direction e,refl,Id -internal, recompiling
+  
+   ￫ warning[W2303]
+   ￮ file '$TESTCASE_ROOT/one.ny' was compiled with incompatible flags -arity 2 -direction e,refl,Id -internal, recompiling
+  
+   ￫ info[I0003]
+   ￮ loading file: $TESTCASE_ROOT/one.ny
+  
+   ￫ info[I0001]
+   ￮ Axiom A assumed
+  
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/one.ny (source)
+  
+   ￫ info[I0001]
+   ￮ Axiom a0 assumed
+  
+
+  $ narya two.ny
+   ￫ warning[W2303]
+   ￮ file '$TESTCASE_ROOT/two.ny' was compiled with incompatible flags -arity 1 -direction d -external, recompiling
+  
+   ￫ warning[W2303]
+   ￮ file '$TESTCASE_ROOT/one.ny' was compiled with incompatible flags -arity 1 -direction d -external, recompiling
+  
+
 Requiring a file multiple times
 
   $ cat >three.ny <<EOF
@@ -43,6 +91,42 @@ Requiring a file multiple times
   
    ￫ info[I0004]
    ￮ file loaded: $TESTCASE_ROOT/three.ny (compiled)
+  
+   ￫ info[I0001]
+   ￮ Axiom a2 assumed
+  
+
+Files are recompiled if their dependencies need to be
+
+  $ touch one.ny
+
+  $ narya -v four.ny
+   ￫ info[I0003]
+   ￮ loading file: $TESTCASE_ROOT/one.ny
+  
+   ￫ info[I0001]
+   ￮ Axiom A assumed
+  
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/one.ny (source)
+  
+   ￫ info[I0003]
+   ￮ loading file: $TESTCASE_ROOT/two.ny
+  
+   ￫ info[I0001]
+   ￮ Axiom a0 assumed
+  
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/two.ny (source)
+  
+   ￫ info[I0003]
+   ￮ loading file: $TESTCASE_ROOT/three.ny
+  
+   ￫ info[I0001]
+   ￮ Axiom a1 assumed
+  
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/three.ny (source)
   
    ￫ info[I0001]
    ￮ Axiom a2 assumed

--- a/test/black/compile.t
+++ b/test/black/compile.t
@@ -41,9 +41,6 @@ Files are recompiled if the flags change
 
   $ narya -dtt -v two.ny
    ￫ warning[W2303]
-   ￮ file '$TESTCASE_ROOT/two.ny' was compiled with incompatible flags -arity 2 -direction e,refl,Id -internal, recompiling
-  
-   ￫ warning[W2303]
    ￮ file '$TESTCASE_ROOT/one.ny' was compiled with incompatible flags -arity 2 -direction e,refl,Id -internal, recompiling
   
    ￫ info[I0003]
@@ -60,9 +57,6 @@ Files are recompiled if the flags change
   
 
   $ narya two.ny
-   ￫ warning[W2303]
-   ￮ file '$TESTCASE_ROOT/two.ny' was compiled with incompatible flags -arity 1 -direction d -external, recompiling
-  
    ￫ warning[W2303]
    ￮ file '$TESTCASE_ROOT/one.ny' was compiled with incompatible flags -arity 1 -direction d -external, recompiling
   
@@ -178,7 +172,10 @@ Import is relative to the file's directory
 
 A file isn't loaded twice even if referred to in different ways
 
-  $ narya -v subdir/one.ny -e 'import "subdir/two"'
+  $ narya -v -e 'import "subdir/one"' -e 'import "subdir/two"'
+   ￫ info[I0004]
+   ￮ file loaded: $TESTCASE_ROOT/subdir/one.ny (compiled)
+  
    ￫ info[I0004]
    ￮ file loaded: $TESTCASE_ROOT/subdir/two.ny (compiled)
   
@@ -269,12 +266,12 @@ Echos are not re-executed in compiled files
   > echo A
   > EOF
 
-  $ narya echo.ny
+  $ narya -e 'import "echo"'
   A
     : Type
   
 
-  $ narya echo.ny
+  $ narya -e 'import "echo"'
    ￫ warning[W2400]
    ￮ not re-executing 'echo' commands when loading compiled file $TESTCASE_ROOT/echo.nyo
   

--- a/test/black/discreteness.t
+++ b/test/black/discreteness.t
@@ -10,7 +10,7 @@ Arbitrary types are not discrete:
   > def T ≔ A⁽ᵈ⁾ a
   > EOF
 
-  $ narya -arity 1 -direction d arb.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
+  $ narya -source-only -arity 1 -direction d arb.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
    ￫ error[E1003]
    ￭ command-line exec string
    1 | def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.
@@ -24,7 +24,7 @@ Arbitrary types are not discrete:
 
 They remain so even when discreteness is on:
 
-  $ narya -arity 1 -direction d -discreteness arb.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
+  $ narya -source-only -arity 1 -direction d -discreteness arb.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
    ￫ error[E1003]
    ￭ command-line exec string
    1 | def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.
@@ -44,7 +44,7 @@ There are no discrete datatypes if discreteness is off:
   > def T ≔ ℕ⁽ᵈ⁾ n
   > EOF
 
-  $ narya -v -arity 1 -direction d natd.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
+  $ narya -source-only -v -arity 1 -direction d natd.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
    ￫ info[I0000]
    ￮ Constant ℕ defined
   
@@ -74,7 +74,7 @@ Discrete datatypes are not themselves propositions:
   > def T : Type ≔ data [ zero. | suc. (_:T) ]
   > EOF
 
-  $ narya -v -arity 1 -direction d -discreteness nat.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
+  $ narya -source-only -v -arity 1 -direction d -discreteness nat.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
    ￫ info[I0000]
    ￮ Constant T defined (discrete)
   
@@ -100,7 +100,7 @@ But their degenerate versions are:
   > def T ≔ ℕ⁽ᵈ⁾ n
   > EOF
 
-  $ narya -v -arity 1 -direction d -discreteness natd.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
+  $ narya -source-only -v -arity 1 -direction d -discreteness natd.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
    ￫ info[I0000]
    ￮ Constant ℕ defined (discrete)
   
@@ -125,7 +125,7 @@ Non-discrete datatypes are not discrete:
   > axiom l : List A
   > def T ≔ (List A)⁽ᵈ⁾ l
 
-  $ narya -v -arity 1 -direction d -discreteness param.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
+  $ narya -source-only -v -arity 1 -direction d -discreteness param.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
    ￫ info[I0000]
    ￮ Constant List defined
   
@@ -159,7 +159,7 @@ Non-discrete datatypes are not discrete:
   > axiom z : iszero n
   > def T ≔ (iszero n)⁽ᵈ⁾ z
 
-  $ narya -v -arity 1 -direction d -discreteness index.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
+  $ narya -source-only -v -arity 1 -direction d -discreteness index.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
    ￫ info[I0000]
    ￮ Constant ℕ defined (discrete)
   
@@ -194,7 +194,7 @@ Non-discrete datatypes are not discrete:
   > axiom f : foo
   > def T ≔ foo⁽ᵈ⁾ f
 
-  $ narya -v -arity 1 -direction d -discreteness constr.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
+  $ narya -source-only -v -arity 1 -direction d -discreteness constr.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
    ￫ info[I0000]
    ￮ Constant foo defined
   
@@ -225,7 +225,7 @@ Non-discrete datatypes are not discrete:
   > def T ≔ even⁽ᵈ⁾ e
   > EOF
 
-  $ narya -v -arity 1 -direction d -discreteness mutual.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
+  $ narya -source-only -v -arity 1 -direction d -discreteness mutual.ny jd.ny -e 'def test (t1 : T) (t2 : T) : Jd T t1 t2 ≔ rfl.'
    ￫ info[I0000]
    ￮ Constants defined mutually:
        even
@@ -253,7 +253,7 @@ Non-discrete datatypes are not discrete:
 
 Some other discrete types:
 
-  $ narya -v -arity 1 -direction d -discreteness -e 'def ℕ : Type ≔ data [ zero. | suc. (_:ℕ) ]' -e 'def ℤ : Type ≔ data [ zero. | suc. (_:ℕ) | negsuc. (_:ℕ) ]' -e 'def btree : Type ≔ data [ leaf. | node. (_:btree) (_:btree) ]'
+  $ narya -source-only -v -arity 1 -direction d -discreteness -e 'def ℕ : Type ≔ data [ zero. | suc. (_:ℕ) ]' -e 'def ℤ : Type ≔ data [ zero. | suc. (_:ℕ) | negsuc. (_:ℕ) ]' -e 'def btree : Type ≔ data [ leaf. | node. (_:btree) (_:btree) ]'
    ￫ info[I0000]
    ￮ Constant ℕ defined (discrete)
   

--- a/test/black/holes.t/run.t
+++ b/test/black/holes.t/run.t
@@ -9,7 +9,7 @@
    ￮ Constant id defined
   
    ￫ info[I0100]
-   ￭ holes.ny
+   ￭ $TESTCASE_ROOT/holes.ny
    7 | def f : A → B ≔ ?
      ^ hole ?0 generated:
        
@@ -20,7 +20,7 @@
    ￮ Constant f defined, containing 1 hole
   
    ￫ info[I0100]
-   ￭ holes.ny
+   ￭ $TESTCASE_ROOT/holes.ny
    9 | def f' : A → B ≔ x ↦ ?
      ^ hole ?1 generated:
        
@@ -35,7 +35,7 @@
    ￮ Constant ℕ defined
   
    ￫ info[I0100]
-   ￭ holes.ny
+   ￭ $TESTCASE_ROOT/holes.ny
    17 | | zero. ↦ ?
       ^ hole ?2 generated:
         
@@ -45,7 +45,7 @@
         ℕ
   
    ￫ info[I0100]
-   ￭ holes.ny
+   ￭ $TESTCASE_ROOT/holes.ny
    18 | | suc. n ↦ ?
       ^ hole ?3 generated:
         
@@ -62,7 +62,7 @@
    ￮ Axiom P assumed
   
    ￫ info[I0100]
-   ￭ holes.ny
+   ￭ $TESTCASE_ROOT/holes.ny
    23 | def anop : ℕ → ℕ → (x : ℕ) → P x ≔ n n0 n ↦ ?
       ^ hole ?4 generated:
         
@@ -76,7 +76,7 @@
    ￮ Constant anop defined, containing 1 hole
   
    ￫ info[I0100]
-   ￭ holes.ny
+   ￭ $TESTCASE_ROOT/holes.ny
    26 | def anop' : ℕ → ℕ → (x : ℕ) → P x ≔ n0 n n ↦ ?
       ^ hole ?5 generated:
         
@@ -90,7 +90,7 @@
    ￮ Constant anop' defined, containing 1 hole
   
    ￫ info[I0100]
-   ￭ holes.ny
+   ￭ $TESTCASE_ROOT/holes.ny
    28 | def anop'' : ℕ → ℕ → (x : ℕ) → P x ≔ n _ n ↦ ?
       ^ hole ?6 generated:
         
@@ -104,7 +104,7 @@
    ￮ Constant anop'' defined, containing 1 hole
   
    ￫ info[I0100]
-   ￭ holes.ny
+   ￭ $TESTCASE_ROOT/holes.ny
    31 | def anop''' : ℕ → ℕ → (x : ℕ) → P x ≔ H _ n ↦ ?
       ^ hole ?7 generated:
         
@@ -121,7 +121,7 @@
    ￮ Constant Σ defined
   
    ￫ info[I0100]
-   ￭ holes.ny
+   ￭ $TESTCASE_ROOT/holes.ny
    39 | def pp : Σ Type (X ↦ X) ≔ ( ? , ? )
       ^ hole ?8 generated:
         
@@ -129,7 +129,7 @@
         Type
   
    ￫ info[I0100]
-   ￭ holes.ny
+   ￭ $TESTCASE_ROOT/holes.ny
    39 | def pp : Σ Type (X ↦ X) ≔ ( ? , ? )
       ^ hole ?9 generated:
         
@@ -140,7 +140,7 @@
    ￮ Constant pp defined, containing 2 holes
   
    ￫ info[I0100]
-   ￭ holes.ny
+   ￭ $TESTCASE_ROOT/holes.ny
    42 | def pp' : Σ Type (X ↦ X) ≔ ( id ? , ? )
       ^ hole ?10 generated:
         
@@ -148,7 +148,7 @@
         Type
   
    ￫ info[I0100]
-   ￭ holes.ny
+   ￭ $TESTCASE_ROOT/holes.ny
    42 | def pp' : Σ Type (X ↦ X) ≔ ( id ? , ? )
       ^ hole ?11 generated:
         
@@ -159,7 +159,7 @@
    ￮ Constant pp' defined, containing 2 holes
   
    ￫ info[I0100]
-   ￭ holes.ny
+   ￭ $TESTCASE_ROOT/holes.ny
    48 |   baz : ?,
       ^ hole ?12 generated:
         
@@ -171,7 +171,7 @@
    ￮ Constant foo defined, containing 1 hole
   
    ￫ info[I0100]
-   ￭ holes.ny
+   ￭ $TESTCASE_ROOT/holes.ny
    53 |   baz : (x:bar) → ?,
       ^ hole ?13 generated:
         
@@ -184,7 +184,7 @@
    ￮ Constant foo' defined, containing 1 hole
   
    ￫ info[I0100]
-   ￭ holes.ny
+   ￭ $TESTCASE_ROOT/holes.ny
    57 |   one : ?,
       ^ hole ?14 generated:
         
@@ -199,7 +199,7 @@
    ￮ Constant gel0 defined, containing 1 hole
   
    ￫ info[I0100]
-   ￭ holes.ny
+   ￭ $TESTCASE_ROOT/holes.ny
    62 |   two : ?
       ^ hole ?15 generated:
         
@@ -215,7 +215,7 @@
    ￮ Constant gel1 defined, containing 1 hole
   
    ￫ info[I0100]
-   ￭ holes.ny
+   ￭ $TESTCASE_ROOT/holes.ny
    66 |   one : ?,
       ^ hole ?16 generated:
         
@@ -227,7 +227,7 @@
         Type
   
    ￫ info[I0100]
-   ￭ holes.ny
+   ￭ $TESTCASE_ROOT/holes.ny
    67 |   two : ?
       ^ hole ?17 generated:
         
@@ -243,7 +243,7 @@
    ￮ Constant gel2 defined, containing 2 holes
   
    ￫ info[I0100]
-   ￭ holes.ny
+   ￭ $TESTCASE_ROOT/holes.ny
    71 | | x .one : ?
       ^ hole ?18 generated:
         
@@ -256,7 +256,7 @@
         Type
   
    ￫ info[I0100]
-   ￭ holes.ny
+   ￭ $TESTCASE_ROOT/holes.ny
    72 | | x .two : ?
       ^ hole ?19 generated:
         
@@ -278,7 +278,7 @@
    ￮ Constant AC defined
   
    ￫ info[I0100]
-   ￭ holes.ny
+   ￭ $TESTCASE_ROOT/holes.ny
    83 |   a ≔ ?,
       ^ hole ?20 generated:
         
@@ -286,7 +286,7 @@
         ℕ → A
   
    ￫ info[I0100]
-   ￭ holes.ny
+   ￭ $TESTCASE_ROOT/holes.ny
    84 |   c ≔ ?
       ^ hole ?21 generated:
         
@@ -312,7 +312,7 @@
     : refl Π A A (refl A) (_ ↦ A) (_ ↦ A) (_ ⤇ refl A) ida ida
   
    ￫ info[I0100]
-   ￭ holes.ny
+   ￭ $TESTCASE_ROOT/holes.ny
    98 | def ideqid'' : Id (A -> A) ida ida := ((x |-> x) : Id (A -> A ) ida ida -> Id (A -> A) ida ida) (u u u |-> ?)
       ^ hole ?22 generated:
         
@@ -326,7 +326,7 @@
    ￮ Constant ideqid'' defined, containing 1 hole
   
    ￫ info[I0100]
-   ￭ holes.ny
+   ￭ $TESTCASE_ROOT/holes.ny
    101 | def afam : Type → Type ≔ X ↦ id ?
        ^ hole ?23 generated:
          
@@ -350,7 +350,7 @@
    ￮ Constant f defined
   
    ￫ info[I0100]
-   ￭ dtt-holes.ny
+   ￭ $TESTCASE_ROOT/dtt-holes.ny
    4 | def g (X : Type) : Type⁽ᵈ⁾ X ≔ (f ?)⁽ᵈ⁾
      ^ hole ?0 generated:
        
@@ -359,7 +359,7 @@
        Type
   
    ￫ error[E0401]
-   ￭ dtt-holes.ny
+   ￭ $TESTCASE_ROOT/dtt-holes.ny
    4 | def g (X : Type) : Type⁽ᵈ⁾ X ≔ (f ?)⁽ᵈ⁾
      ^ term synthesized type
          Type⁽ᵈ⁾ ?0{…}

--- a/test/black/import.t
+++ b/test/black/import.t
@@ -94,7 +94,7 @@ Requiring a file multiple times
    ￮ file loaded: $TESTCASE_ROOT/three.ny
   
    ￫ error[E0300]
-   ￭ twothree.ny
+   ￭ $TESTCASE_ROOT/twothree.ny
    3 | axiom a2 : Id A a0 a1
      ^ unbound variable: A
   
@@ -262,7 +262,7 @@ Quitting in imports quits only that file
    ￮ Axiom A assumed
   
    ￫ info[I0200]
-   ￮ execution of qone.ny terminated by quit
+   ￮ execution of $TESTCASE_ROOT/qone.ny terminated by quit
   
    ￫ info[I0004]
    ￮ file loaded: $TESTCASE_ROOT/qone.ny

--- a/test/black/import.t
+++ b/test/black/import.t
@@ -9,7 +9,7 @@ Import files
   > axiom a0 : A
   > EOF
 
-  $ narya -v two.ny
+  $ narya -source-only -v two.ny
    ￫ info[I0003]
    ￮ loading file: $TESTCASE_ROOT/one.ny
   
@@ -17,7 +17,7 @@ Import files
    ￮ Axiom A assumed
   
    ￫ info[I0004]
-   ￮ file loaded: $TESTCASE_ROOT/one.ny
+   ￮ file loaded: $TESTCASE_ROOT/one.ny (source)
   
    ￫ info[I0001]
    ￮ Axiom a0 assumed
@@ -25,7 +25,7 @@ Import files
 
 Command-line strings see namespaces from explicitly loaded files only
 
-  $ narya -v two.ny -e 'axiom a1 : A'
+  $ narya -source-only -v two.ny -e 'axiom a1 : A'
    ￫ info[I0003]
    ￮ loading file: $TESTCASE_ROOT/one.ny
   
@@ -33,7 +33,7 @@ Command-line strings see namespaces from explicitly loaded files only
    ￮ Axiom A assumed
   
    ￫ info[I0004]
-   ￮ file loaded: $TESTCASE_ROOT/one.ny
+   ￮ file loaded: $TESTCASE_ROOT/one.ny (source)
   
    ￫ info[I0001]
    ￮ Axiom a0 assumed
@@ -45,7 +45,7 @@ Command-line strings see namespaces from explicitly loaded files only
   
   [1]
 
-  $ narya -v one.ny -e 'axiom a1 : A'
+  $ narya -source-only -v one.ny -e 'axiom a1 : A'
    ￫ info[I0001]
    ￮ Axiom A assumed
   
@@ -65,7 +65,7 @@ Requiring a file multiple times
   > import "three"
   > axiom a2 : Id A a0 a1
 
-  $ narya -v twothree.ny
+  $ narya -source-only -v twothree.ny
    ￫ info[I0003]
    ￮ loading file: $TESTCASE_ROOT/two.ny
   
@@ -76,13 +76,13 @@ Requiring a file multiple times
    ￮ Axiom A assumed
   
    ￫ info[I0004]
-   ￮ file loaded: $TESTCASE_ROOT/one.ny
+   ￮ file loaded: $TESTCASE_ROOT/one.ny (source)
   
    ￫ info[I0001]
    ￮ Axiom a0 assumed
   
    ￫ info[I0004]
-   ￮ file loaded: $TESTCASE_ROOT/two.ny
+   ￮ file loaded: $TESTCASE_ROOT/two.ny (source)
   
    ￫ info[I0003]
    ￮ loading file: $TESTCASE_ROOT/three.ny
@@ -91,7 +91,7 @@ Requiring a file multiple times
    ￮ Axiom a1 assumed
   
    ￫ info[I0004]
-   ￮ file loaded: $TESTCASE_ROOT/three.ny
+   ￮ file loaded: $TESTCASE_ROOT/three.ny (source)
   
    ￫ error[E0300]
    ￭ $TESTCASE_ROOT/twothree.ny
@@ -106,7 +106,7 @@ Requiring a file multiple times
   > import "three"
   > axiom a2 : Id A a0 a1
 
-  $ narya -v four.ny
+  $ narya -source-only -v four.ny
    ￫ info[I0003]
    ￮ loading file: $TESTCASE_ROOT/one.ny
   
@@ -114,7 +114,7 @@ Requiring a file multiple times
    ￮ Axiom A assumed
   
    ￫ info[I0004]
-   ￮ file loaded: $TESTCASE_ROOT/one.ny
+   ￮ file loaded: $TESTCASE_ROOT/one.ny (source)
   
    ￫ info[I0003]
    ￮ loading file: $TESTCASE_ROOT/two.ny
@@ -123,7 +123,7 @@ Requiring a file multiple times
    ￮ Axiom a0 assumed
   
    ￫ info[I0004]
-   ￮ file loaded: $TESTCASE_ROOT/two.ny
+   ￮ file loaded: $TESTCASE_ROOT/two.ny (source)
   
    ￫ info[I0003]
    ￮ loading file: $TESTCASE_ROOT/three.ny
@@ -132,7 +132,7 @@ Requiring a file multiple times
    ￮ Axiom a1 assumed
   
    ￫ info[I0004]
-   ￮ file loaded: $TESTCASE_ROOT/three.ny
+   ￮ file loaded: $TESTCASE_ROOT/three.ny (source)
   
    ￫ info[I0001]
    ￮ Axiom a2 assumed
@@ -148,7 +148,7 @@ Circular dependency
   > import "foo"
   > EOF
 
-  $ narya foo.ny
+  $ narya -source-only foo.ny
    ￫ error[E2300]
    ￮ circular imports:
      $TESTCASE_ROOT/foo.ny
@@ -170,7 +170,7 @@ Import is relative to the file's directory
   > axiom a : A
   > EOF
 
-  $ narya -v -e 'import "subdir/two"'
+  $ narya -source-only -v -e 'import "subdir/two"'
    ￫ info[I0003]
    ￮ loading file: $TESTCASE_ROOT/subdir/two.ny
   
@@ -181,18 +181,18 @@ Import is relative to the file's directory
    ￮ Axiom A assumed
   
    ￫ info[I0004]
-   ￮ file loaded: $TESTCASE_ROOT/subdir/one.ny
+   ￮ file loaded: $TESTCASE_ROOT/subdir/one.ny (source)
   
    ￫ info[I0001]
    ￮ Axiom a assumed
   
    ￫ info[I0004]
-   ￮ file loaded: $TESTCASE_ROOT/subdir/two.ny
+   ￮ file loaded: $TESTCASE_ROOT/subdir/two.ny (source)
   
 
 A file isn't loaded twice even if referred to in different ways
 
-  $ narya -v subdir/one.ny -e 'import "subdir/two"'
+  $ narya -source-only -v subdir/one.ny -e 'import "subdir/two"'
    ￫ info[I0001]
    ￮ Axiom A assumed
   
@@ -203,7 +203,7 @@ A file isn't loaded twice even if referred to in different ways
    ￮ Axiom a assumed
   
    ￫ info[I0004]
-   ￮ file loaded: $TESTCASE_ROOT/subdir/two.ny
+   ￮ file loaded: $TESTCASE_ROOT/subdir/two.ny (source)
   
 
 Notations are used from explicitly imported files, but not transitively.
@@ -225,12 +225,12 @@ Notations are used from explicitly imported files, but not transitively.
   > notation 0 f2 : x "%" y := f x y
   > EOF
 
-  $ narya n1.ny n3.ny -e 'echo a % a'
+  $ narya -source-only n1.ny n3.ny -e 'echo a % a'
   a % a
     : A
   
 
-  $ narya n1.ny n3.ny -e 'echo a & a'
+  $ narya -source-only n1.ny n3.ny -e 'echo a & a'
   a
     : A
   
@@ -254,7 +254,7 @@ Quitting in imports quits only that file
   > axiom a0 : A
   > EOF
 
-  $ narya -v qtwo.ny
+  $ narya -source-only -v qtwo.ny
    ￫ info[I0003]
    ￮ loading file: $TESTCASE_ROOT/qone.ny
   
@@ -265,7 +265,7 @@ Quitting in imports quits only that file
    ￮ execution of $TESTCASE_ROOT/qone.ny terminated by quit
   
    ￫ info[I0004]
-   ￮ file loaded: $TESTCASE_ROOT/qone.ny
+   ￮ file loaded: $TESTCASE_ROOT/qone.ny (source)
   
    ￫ info[I0001]
    ￮ Axiom a0 assumed

--- a/test/black/letin.t
+++ b/test/black/letin.t
@@ -10,7 +10,7 @@ Testing let-bindings
   > axiom f : (x:A) → B x → B x
   > EOF
 
-  $ narya -v pre.ny -e "def a0' : A := let id ≔ ((x ↦ x) : A → A) in id a0" -e "def test : Id A a0 a0' := refl a0"
+  $ narya -source-only -v pre.ny -e "def a0' : A := let id ≔ ((x ↦ x) : A → A) in id a0" -e "def test : Id A a0 a0' := refl a0"
    ￫ info[I0001]
    ￮ Axiom A assumed
   
@@ -39,7 +39,7 @@ Testing let-bindings
    ￮ Constant test defined
   
 
-  $ narya -v pre.ny -e "def a0' : A := let id : A → A ≔ x ↦ x in id a0" -e "def test : Id A a0 a0' := refl a0"
+  $ narya -source-only -v pre.ny -e "def a0' : A := let id : A → A ≔ x ↦ x in id a0" -e "def test : Id A a0 a0' := refl a0"
    ￫ info[I0001]
    ￮ Axiom A assumed
   
@@ -70,7 +70,7 @@ Testing let-bindings
 
 It matters what the variable is bound to:
 
-  $ narya -v pre.ny -e "def a0' : A := let id : A → A ≔ x ↦ a1 in id a0" -e "def untest : Id A a0 a0' := refl a0"
+  $ narya -source-only -v pre.ny -e "def a0' : A := let id : A → A ≔ x ↦ a1 in id a0" -e "def untest : Id A a0 a0' := refl a0"
    ￫ info[I0001]
    ￮ Axiom A assumed
   
@@ -107,7 +107,7 @@ It matters what the variable is bound to:
 
 Ap on let:
 
-  $ narya -v pre.ny -e "def a2' := refl ((y ↦ let id : A → A ≔ x ↦ x in id y) : A → A) a0 a1 a2" -e "def test : Id (Id A a0 a1) a2 a2' := refl a2"
+  $ narya -source-only -v pre.ny -e "def a2' := refl ((y ↦ let id : A → A ≔ x ↦ x in id y) : A → A) a0 a1 a2" -e "def test : Id (Id A a0 a1) a2 a2' := refl a2"
    ￫ info[I0001]
    ￮ Axiom A assumed
   
@@ -138,7 +138,7 @@ Ap on let:
 
 Let affects typechecking:
 
-  $ narya -v pre.ny -e "def b' : B a0 := let x ≔ a0 in f x b" -e "def untest : B a0 ≔ ((x ↦ f x b) : A → B a0) a0"
+  $ narya -source-only -v pre.ny -e "def b' : B a0 := let x ≔ a0 in f x b" -e "def untest : B a0 ≔ ((x ↦ f x b) : A → B a0) a0"
    ￫ info[I0001]
    ￮ Axiom A assumed
   
@@ -172,7 +172,7 @@ Let affects typechecking:
 
 Let can check in addition to synthesize:
 
-  $ narya -v pre.ny -e "def aconst : A → A ≔ let x ≔ a0 in y ↦ x"
+  $ narya -source-only -v pre.ny -e "def aconst : A → A ≔ let x ≔ a0 in y ↦ x"
    ￫ info[I0001]
    ￮ Axiom A assumed
   
@@ -200,7 +200,7 @@ Let can check in addition to synthesize:
 
 Let is allowed in case trees:
 
-  $ narya -v pre.ny -e "def atree : A → A ≔ let x ≔ a0 in y ↦ y" -e "echo atree"
+  $ narya -source-only -v pre.ny -e "def atree : A → A ≔ let x ≔ a0 in y ↦ y" -e "echo atree"
    ￫ info[I0001]
    ￮ Axiom A assumed
   
@@ -236,7 +236,7 @@ Let can contain case trees:
   > axiom u : bool
   > EOF
 
-  $ narya -v letcase.ny -e 'def not : bool -> bool := x |-> let n : bool := match x [ true. |-> false. | false. |-> true. ] in n' -e 'echo not true.' -e 'echo not false.' -e 'echo not u'
+  $ narya -source-only -v letcase.ny -e 'def not : bool -> bool := x |-> let n : bool := match x [ true. |-> false. | false. |-> true. ] in n' -e 'echo not true.' -e 'echo not false.' -e 'echo not u'
    ￫ info[I0000]
    ￮ Constant bool defined
   
@@ -256,7 +256,7 @@ Let can contain case trees:
     : bool
   
 
-  $ narya -v letcase.ny -e 'def not : bool -> bool := x |-> let n : bool -> bool := y |-> match y [ true. |-> false. | false. |-> true. ] in n x' -e 'echo not true.' -e 'echo not false.' -e 'echo not u'
+  $ narya -source-only -v letcase.ny -e 'def not : bool -> bool := x |-> let n : bool -> bool := y |-> match y [ true. |-> false. | false. |-> true. ] in n x' -e 'echo not true.' -e 'echo not false.' -e 'echo not u'
    ￫ info[I0000]
    ￮ Constant bool defined
   
@@ -278,7 +278,7 @@ Let can contain case trees:
 
 Synthesizing matches don't need to be annotated
 
-  $ narya -v letcase.ny -e 'def not : bool -> bool := x |-> let n := match x [ true. |-> (false. : bool) | false. |-> true. ] in n' -e 'echo not true.' -e 'echo not false.' -e 'echo not u'
+  $ narya -source-only -v letcase.ny -e 'def not : bool -> bool := x |-> let n := match x [ true. |-> (false. : bool) | false. |-> true. ] in n' -e 'echo not true.' -e 'echo not false.' -e 'echo not u'
    ￫ info[I0000]
    ￮ Constant bool defined
   
@@ -334,7 +334,7 @@ Let doesn't make a case tree unless it needs to:
 
 Matches outside case trees can be implicitly wrapped in a let-binding:
 
-  $ narya -v letcase.ny -e 'def not (b : bool) : bool ≔ ((x ↦ x) : bool → bool) (match b [ true. ↦ false. | false. ↦ true. ])' -e 'echo not true.' -e 'echo not false.' -e 'echo not u'
+  $ narya -source-only -v letcase.ny -e 'def not (b : bool) : bool ≔ ((x ↦ x) : bool → bool) (match b [ true. ↦ false. | false. ↦ true. ])' -e 'echo not true.' -e 'echo not false.' -e 'echo not u'
    ￫ info[I0000]
    ￮ Constant bool defined
   

--- a/test/black/match.t/run.t
+++ b/test/black/match.t/run.t
@@ -33,7 +33,7 @@
    ￮ Constant contra defined
   
    ￫ hint[E1101]
-   ￭ matchterm.ny
+   ￭ $TESTCASE_ROOT/matchterm.ny
    12 | def doublematch (n : ℕ) : bool ≔ match n [ zero. ↦ false. | suc. k ↦ match n [ zero. ↦ true. | suc. _ ↦ false. ]]
       ^ match will not refine the goal or context (discriminee is let-bound): n
   
@@ -139,7 +139,7 @@
    ￮ Constant ⊤ defined
   
    ￫ hint[H0403]
-   ￭ multi.ny
+   ￭ $TESTCASE_ROOT/multi.ny
    82 | def ⊤eq⊥ : Id Type ⊤ ⊥ ≔ Gel ⊤ ⊥ []
       ^ matching lambda encountered outside case tree, wrapping in implicit let-binding
   

--- a/test/parser/permute_args.ml
+++ b/test/parser/permute_args.ml
@@ -10,9 +10,15 @@ let () =
   assume "foo" "A → A → A";
   let foo = Option.get (Scope.lookup [ "foo" ]) in
   let _ =
-    State.Current.add_user "amp" (Infix No.zero)
-      [ `Var ("x", `Nobreak, []); `Op (Op "&", `Break, []); `Var ("y", `None, []) ]
-      (`Constant foo) [ "y"; "x" ] in
+    State.Current.add_user
+      (User
+         {
+           name = "amp";
+           fixity = Infix No.zero;
+           pattern = [ `Var ("x", `Nobreak, []); `Op (Op "&", `Break, []); `Var ("y", `None, []) ];
+           key = `Constant foo;
+           val_vars = [ "y"; "x" ];
+         }) in
   assume "a" "A";
   assume "b" "A";
   equal_at "foo a b" "b & a" "A";

--- a/test/testutil/arity.ml
+++ b/test/testutil/arity.ml
@@ -1,0 +1,7 @@
+let installed = ref false
+
+let install () =
+  if not !installed then (
+    Dim.Endpoints.set_len 2;
+    Dim.Endpoints.set_internal true;
+    installed := true)

--- a/test/testutil/mcp.ml
+++ b/test/testutil/mcp.ml
@@ -6,9 +6,7 @@ open Value
 open Norm
 open Asai.Range
 
-let () =
-  Dim.Endpoints.set_len 2;
-  Dim.Endpoints.set_internal true
+let () = Arity.install ()
 
 (* The current context of assumptions, including names. *)
 type ctx = Ctx : ('n, 'b) Ctx.t * (string option, 'n) Bwv.t -> ctx

--- a/test/testutil/pmp.ml
+++ b/test/testutil/pmp.ml
@@ -6,10 +6,7 @@ open Norm
 open Parser
 open Asai.Range
 
-let () =
-  Dim.Endpoints.set_len 2;
-  Dim.Endpoints.set_internal true
-
+let () = Arity.install ()
 let unlocated (value : 'a) : 'a located = { value; loc = None }
 
 (* Poor man's parser, reusing the OCaml parser to make a vaguely usable syntax *)

--- a/test/testutil/print.ml
+++ b/test/testutil/print.ml
@@ -3,10 +3,7 @@ open Parser
 open Print
 open Core
 
-let () =
-  Dim.Endpoints.set_len 2;
-  Dim.Endpoints.set_internal true
-
+let () = Arity.install ()
 let margin = ref 80
 let set_margin n = margin := n
 

--- a/test/testutil/repl.ml
+++ b/test/testutil/repl.ml
@@ -38,7 +38,7 @@ let assume (name : string) (ty : string) : unit =
   match Parse.Term.final p with
   | Term { value = Ident (name, _); _ } ->
       Parser.Command.check_constant_name name;
-      let const = Scope.define name in
+      let const = Scope.define Compunit.basic name in
       Reporter.try_with ~fatal:(fun d ->
           Scope.modify_visible (Yuujinchou.Language.except name);
           Scope.modify_export (Yuujinchou.Language.except name);
@@ -55,7 +55,7 @@ let def (name : string) (ty : string) (tm : string) : unit =
   | Term { value = Ident (name, _); _ } ->
       Reporter.tracef "when defining %s" (String.concat "." name) @@ fun () ->
       Parser.Command.check_constant_name name;
-      let const = Scope.define name in
+      let const = Scope.define Compunit.basic name in
       Reporter.try_with ~fatal:(fun d ->
           Scope.modify_visible (Yuujinchou.Language.except name);
           Scope.modify_export (Yuujinchou.Language.except name);
@@ -132,6 +132,7 @@ let run f =
   Readback.Display.run ~env:false @@ fun () ->
   Discreteness.run ~env:false @@ fun () ->
   Discrete.run ~init:Constant.Map.empty @@ fun () ->
+  Compunit.Current.run ~env:Compunit.basic @@ fun () ->
   Reporter.run ~emit:Terminal.display ~fatal:(fun d ->
       Terminal.display d;
       raise (Failure "Fatal error"))

--- a/test/testutil/repl.ml
+++ b/test/testutil/repl.ml
@@ -15,9 +15,7 @@ open Value
 open Raw
 open Asai.Range
 
-let () =
-  Dim.Endpoints.set_len 2;
-  Dim.Endpoints.set_internal true
+let () = Arity.install ()
 
 let parse_term (tm : string) : N.zero check located =
   let p = Parse.Term.parse (`String { content = tm; title = Some "user-supplied term" }) in

--- a/test/testutil/showparse.ml
+++ b/test/testutil/showparse.ml
@@ -1,8 +1,6 @@
 open Parser
 
-let () =
-  Dim.Endpoints.set_len 2;
-  Dim.Endpoints.set_internal true
+let () = Arity.install ()
 
 (* Translate a parse observation into something that shows the names of notations rather than their internal abstract representations, for easier inspection and testing.  Note that since we intercept the parse tree before the "compilation" step, there is no name resolution, so this doesn't need to be run inside a Yuujinchou handler and can use unbound variables. *)
 

--- a/test/white/constants.ml
+++ b/test/white/constants.ml
@@ -32,8 +32,8 @@ let () =
   equal_at "ab .snd" "b" "B a";
   equal_at "ab .0" "a" "A";
   equal_at "ab .1" "b" "B a";
-  (match Global.find_opt (Option.get (Parser.Scope.lookup [ "ab" ])) with
-  | Some (_, Defined _) -> ()
+  (match Global.find (Option.get (Parser.Scope.lookup [ "ab" ])) with
+  | _, Defined _ -> ()
   | _ -> raise (Failure "pair wasn't defined to be a tree"));
   def "zero_zero'" "Σ CN (_ ↦ CN)" "( fst ≔ zero , snd ≔ zero )";
   equal_at "zero_zero" "zero_zero'" "Σ CN (_ ↦ CN)";


### PR DESCRIPTION
When a file is successfully typechecked, we save a "compiled" version of it containing its typechecked definitions.  Then when that file is imported again in a later run, we load the compiled version instead if it is up-to-date and valid, saving the time of re-typechecking it.  See the updated README for more details.