### PR TITLE
proof-general solving holes

### DIFF
--- a/proofgeneral/narya.el
+++ b/proofgeneral/narya.el
@@ -273,9 +273,8 @@ it won't try to duplicate our work."
   "Solve the current hole with a user-provided term."
   (interactive)
   (let ((hole-overlay (car (seq-filter (lambda (ovl)
-                                         (eq (get-char-property (point) 'narya-hole)
-                                             (overlay-get ovl 'narya-hole)))
-                                       narya-hole-overlays))))
+                                         (overlay-get ovl 'narya-hole))
+                                       (overlays-at (point))))))
     (if (not hole-overlay)
         ;; If the cursor is not on a hole, display a warning message.
         (message "Place the cursor on a hole.")
@@ -297,6 +296,7 @@ it won't try to duplicate our work."
             (delete-overlay hole-overlay)
             (setq narya-hole-overlays (delq hole-overlay narya-hole-overlays))
             (message "Hole solved.")))))))
+
 
 (keymap-set narya-mode-map "C-c C-SPC" 'narya-solve-hole)
 

--- a/proofgeneral/narya.el
+++ b/proofgeneral/narya.el
@@ -283,10 +283,8 @@ it won't try to duplicate our work."
       (let ((term (read-string "Enter the term to solve the hole: ")))
         ;; Execute the solve command with the entered term.
         (proof-shell-invisible-command
-         (format "solve %d := %s" (overlay-get hole-overlay 'narya-hole) term))
-        
-        ;; Wait for the process to output its result
-        (accept-process-output (get-buffer-process proof-shell-buffer) 1) ;; Adjust timeout if needed
+         (format "solve %d := %s" (overlay-get hole-overlay 'narya-hole) term)
+         t)
         ;; Check the output after executing the solve command.
         (if (eq proof-shell-last-output-kind 'error)
             ;; Display error message if the entered term is incorrect.


### PR DESCRIPTION
I attempted to handle "solve a hole" in proofgeneral mode. 

- When a hole created after a load (C-c C-n), use C-c C-SPC to enter the process
- Narya then asks for hole number. If the hole d exists, and the user prompts d, then Narya asks for a term.
- Provide the term and press enter. Then Narya fill the hole and load again.
- Since hole numbers increase after a new load, if the user is not sure about the hole number, one can use C-c C-? to see all holes.

I think it works, but let me know if you have any suggestions.