### PR TITLE
Accumulate and report multiple errors when possible

### DIFF
--- a/bin/narya.ml
+++ b/bin/narya.ml
@@ -100,9 +100,9 @@ let rec repl terminal history buf =
         let* () = Lwt_io.flush Lwt_io.stdout in
         (* In interactive mode, we display all messages verbosely, and don't quit on fatal errors except for the Quit command. *)
         Reporter.try_with
-          ~emit:(fun d -> Terminal.display ~output:stdout d)
+          ~emit:(fun d -> Reporter.display ~output:stdout d)
           ~fatal:(fun d ->
-            Terminal.display ~output:stdout d;
+            Reporter.display ~output:stdout d;
             match d.message with
             | Quit _ -> exit 0
             | _ -> ())
@@ -153,8 +153,8 @@ let rec interact_pg () : unit =
         ~emit:(fun d ->
           match d.message with
           | Hole _ -> holes := Snoc (!holes, d.message)
-          | _ -> Terminal.display ~use_ansi:true ~output:stdout d)
-        ~fatal:(fun d -> Terminal.display ~use_ansi:true ~output:stdout d)
+          | _ -> Reporter.display ~use_ansi:true ~output:stdout d)
+        ~fatal:(fun d -> Reporter.display ~use_ansi:true ~output:stdout d)
         (fun () ->
           try
             do_command (Command.parse_single cmd);
@@ -177,8 +177,8 @@ let () =
   Mbwd.miter
     (fun [ file ] ->
       let p, src = Parser.Command.Parse.start_parse (`File file) in
-      Reporter.try_with ~emit:(Terminal.display ~output:stdout)
-        ~fatal:(Terminal.display ~output:stdout) (fun () -> Execute.batch true [] p src))
+      Reporter.try_with ~emit:(Reporter.display ~output:stdout)
+        ~fatal:(Reporter.display ~output:stdout) (fun () -> Execute.batch true [] p src))
     [ !fake_interacts ];
   if !interactive then Lwt_main.run (interact ())
   else if !proofgeneral then (

--- a/js/jsnarya.ml
+++ b/js/jsnarya.ml
@@ -26,8 +26,8 @@ let rec interact_js : string -> result =
   let buf = Buffer.create 70 in
   Sys_js.set_channel_flusher stdout (fun str -> Buffer.add_string buf str);
   Reporter.try_with
-    ~emit:(fun d -> Terminal.display ~use_ansi:true ~output:stdout d)
-    ~fatal:(fun d -> Terminal.display ~use_ansi:true ~output:stdout d)
+    ~emit:(fun d -> Reporter.display ~use_ansi:true ~output:stdout d)
+    ~fatal:(fun d -> Reporter.display ~use_ansi:true ~output:stdout d)
     (fun () -> do_command (Command.parse_single cmd));
   Out_channel.flush stdout;
   (* Now we perform the "Next" effect, which returns control to the browser until the user enters another command.  At that point execution resumes here with a return value of the next command to execute, which we then pass off to ourselves recursively. *)

--- a/lib/core/domvars.ml
+++ b/lib/core/domvars.ml
@@ -67,5 +67,6 @@ let rec ext_tel :
         | Some x -> Some x
         | None -> x' in
       let ctx, env, vars, nfs =
-        ext_tel (Ctx.cube_vis ctx x newnfs) (Ext (env, D.plus_zero m, newvars)) xs rest ac ec in
+        ext_tel (Ctx.cube_vis ctx x newnfs) (Ext (env, D.plus_zero m, Ok newvars)) xs rest ac ec
+      in
       (ctx, env, newvars :: vars, newnfs :: nfs)

--- a/lib/core/equal.ml
+++ b/lib/core/equal.ml
@@ -45,7 +45,7 @@ module Equal = struct
         (* Now we take the projections and compare them at appropriate types.  It suffices to use the fields of x when computing the types of the fields, since we proceed to check the fields for equality *in order* and thus by the time we are checking equality of any particular field of x and y, the previous fields of x and y are already known to be equal, and the type of the current field can only depend on these.  (This latter is a semantic constraint on the kinds of generalized records that can sensibly admit eta-conversion.) *)
         BwdM.miterM
           (fun [ (fld, _) ] ->
-            equal_at ctx (field_term x fld) (field_term y fld) (tyof_field x ty fld))
+            equal_at ctx (field_term x fld) (field_term y fld) (tyof_field (Ok x) ty fld))
           [ fields ]
     (* At a codatatype without eta, there are no kinetic structs, only comatches, and those are not compared componentwise, only as neutrals, since they are generative, so we don't need a clause for it. *)
     (* At a higher-dimensional version of a discrete datatype, any two terms are equal.  Note that we do not check here whether discreteness is on: that affects datatypes when they are *defined*, not when they are used. *)
@@ -264,7 +264,7 @@ module Equal = struct
           (Ext
              ( env,
                D.plus_zero (TubeOf.inst tyarg),
-               TubeOf.plus_cube (val_of_norm_tube tyarg) (CubeOf.singleton x) ))
+               Ok (TubeOf.plus_cube (val_of_norm_tube tyarg) (CubeOf.singleton x)) ))
           xs ys tys tyargs
     | _ -> fatal (Anomaly "length mismatch in equal_at_tel")
 

--- a/lib/core/global.mli
+++ b/lib/core/global.mli
@@ -39,6 +39,8 @@ val add_hole :
 val hole_exists : ('a, 'b, 's) Meta.t -> bool
 val with_definition : Constant.t -> definition -> (unit -> 'a) -> 'a
 val with_meta_definition : ('a, 'b, 's) Meta.t -> ('b, 's) term -> (unit -> 'x) -> 'x
+val without_definition : Constant.t -> Reporter.Code.t -> (unit -> 'a) -> 'a
+val without_meta_definition : ('a, 'b, 's) Meta.t -> Reporter.Code.t -> (unit -> 'x) -> 'x
 
 type data
 

--- a/lib/core/metadef.ml
+++ b/lib/core/metadef.ml
@@ -6,7 +6,7 @@ open Term
 type ('a, 'b, 's) t = {
   energy : 's energy;
   tm : [ `Defined of ('b, 's) term | `Axiom | `Undefined ];
-  (* If a metavariable were "lifted" to top level with pi-types, then its type would be composed of its context and the type in that context.  We instead store them separately without doing the lifting. *)
+  (* If a metavariable were "lifted" to top level with pi-types, then its type would be the pi-type over its context of the type in that context.  We instead store them separately without doing the lifting. *)
   termctx : ('a, 'b) Termctx.t;
   ty : ('b, kinetic) term;
 }

--- a/lib/core/readback.ml
+++ b/lib/core/readback.ml
@@ -45,14 +45,14 @@ and readback_at : type a z. (z, a) Ctx.t -> kinetic value -> kinetic value -> (a
             let fields =
               Abwd.mapi
                 (fun fld (fldtm, l) ->
-                  (readback_at ctx (force_eval_term fldtm) (tyof_field tm ty fld), l))
+                  (readback_at ctx (force_eval_term fldtm) (tyof_field (Ok tm) ty fld), l))
                 tmflds in
             Some (Term.Struct (Eta, dim, fields, energy))
         (* In addition, if the record type is transparent, or if it's translucent and the term is a tuple in a case tree, and we are reading back for display (rather than for internal typechecking purposes), we do an eta-expanding readback. *)
         | _, `Transparent l when Display.read () ->
             let fields =
               Abwd.mapi
-                (fun fld _ -> (readback_at ctx (field_term tm fld) (tyof_field tm ty fld), l))
+                (fun fld _ -> (readback_at ctx (field_term tm fld) (tyof_field (Ok tm) ty fld), l))
                 fields in
             Some (Struct (Eta, dim, fields, Kinetic))
         | Uninst (Neu { value; _ }, _), `Translucent l when Display.read () -> (
@@ -60,7 +60,8 @@ and readback_at : type a z. (z, a) Ctx.t -> kinetic value -> kinetic value -> (a
             | Val (Struct _) ->
                 let fields =
                   Abwd.mapi
-                    (fun fld _ -> (readback_at ctx (field_term tm fld) (tyof_field tm ty fld), l))
+                    (fun fld _ ->
+                      (readback_at ctx (field_term tm fld) (tyof_field (Ok tm) ty fld), l))
                     fields in
                 Some (Struct (Eta, dim, fields, Kinetic))
             | _ -> None)
@@ -226,7 +227,7 @@ and readback_at_tel :
            (Ext
               ( env,
                 D.plus_zero (TubeOf.inst tyarg),
-                TubeOf.plus_cube (val_of_norm_tube tyarg) (CubeOf.singleton x) ))
+                Ok (TubeOf.plus_cube (val_of_norm_tube tyarg) (CubeOf.singleton x)) ))
            xs tys tyargs
   | _ -> fatal (Anomaly "length mismatch in equal_at_tel")
 
@@ -305,7 +306,7 @@ let readback_entry :
       let fields =
         Bwv.map
           (fun (f, x) ->
-            let fldty = readback_val ctx (tyof_field top.tm top.ty f) in
+            let fldty = readback_val ctx (tyof_field (Ok top.tm) top.ty f) in
             (f, x, fldty))
           fields in
       let bindings = readback_bindings ctx bindings in

--- a/lib/core/syntax.ml
+++ b/lib/core/syntax.ml
@@ -438,7 +438,9 @@ module rec Value : sig
         ('n, 'b) env * ('n, 'k, 'nk) D.plus * ('nk, kinetic lazy_eval) CubeOf.t
         -> ('n, ('b, 'k) snoc) env
     | Ext :
-        ('n, 'b) env * ('n, 'k, 'nk) D.plus * ('nk, kinetic value) CubeOf.t
+        ('n, 'b) env
+        * ('n, 'k, 'nk) D.plus
+        * (('nk, kinetic value) CubeOf.t, Reporter.Code.t) Result.t
         -> ('n, ('b, 'k) snoc) env
     | Act : ('n, 'b) env * ('m, 'n) op -> ('m, 'b) env
     | Permute : ('a, 'b) Tbwd.permute * ('n, 'b) env -> ('n, 'a) env
@@ -577,11 +579,15 @@ end = struct
   and (_, _) env =
     | Emp : 'n D.t -> ('n, emp) env
     (* The (n+k)-cube here is morally a k-cube of n-cubes, representing a k-dimensional "cube variable" consisting of some number of "real" variables indexed by the faces of a k-cube, each of which has an n-cube of values representing a value and its boundaries.  But this contains the same data as an (n+k)-cube since a strict face of (n+k) decomposes uniquely as a strict face of n plus a strict face of k, and it seems to be more convenient to store it as a single (n+k)-cube. *)
+    (* We have two kinds of variable bindings in an environment: lazy and non-lazy. *)
     | LazyExt :
         ('n, 'b) env * ('n, 'k, 'nk) D.plus * ('nk, kinetic lazy_eval) CubeOf.t
         -> ('n, ('b, 'k) snoc) env
+    (* We also allow Error binding in an environment, indicating that that variable is not actually usable, usually due to an earlier error in typechecking that we've continued on from anyway.  *)
     | Ext :
-        ('n, 'b) env * ('n, 'k, 'nk) D.plus * ('nk, kinetic value) CubeOf.t
+        ('n, 'b) env
+        * ('n, 'k, 'nk) D.plus
+        * (('nk, kinetic value) CubeOf.t, Reporter.Code.t) Result.t
         -> ('n, ('b, 'k) snoc) env
     | Act : ('n, 'b) env * ('m, 'n) op -> ('m, 'b) env
     | Permute : ('a, 'b) Tbwd.permute * ('n, 'b) env -> ('n, 'a) env

--- a/lib/top/top.ml
+++ b/lib/top/top.ml
@@ -68,8 +68,6 @@ let do_command = function
       Print.pp_ws `None ppf last;
       Format.pp_print_newline ppf ()
 
-module Terminal = Asai.Tty.Make (Core.Reporter.Code)
-
 (* This function is called to wrap whatever "interactive mode" is implemented by the caller.  It sets up the environment and all the effect handlers based on the global flags, loads all the files and strings specified in the global flags, and then runs the callback. *)
 let run_top ?use_ansi ?(exiter = fun () -> exit 1) f =
   Parser.Unparse.install ();
@@ -91,9 +89,9 @@ let run_top ?use_ansi ?(exiter = fun () -> exit 1) f =
   Reporter.run
     ~emit:(fun d ->
       if !verbose || d.severity = Error || d.severity = Warning then
-        Terminal.display ?use_ansi ~output:stderr d)
+        Reporter.display ?use_ansi ~output:stderr d)
     ~fatal:(fun d ->
-      Terminal.display ?use_ansi ~output:stderr d;
+      Reporter.display ?use_ansi ~output:stderr d;
       exiter ())
   @@ fun () ->
   if !arity < 1 || !arity > 9 then Reporter.fatal (Unimplemented "arities outside [1,9]");

--- a/test/black/multierror.t
+++ b/test/black/multierror.t
@@ -341,3 +341,77 @@ Even trivial dependency blocks going on, as long as there is the potential for d
      ^ term synthesized type A but is being checked against type Type
   
   [1]
+
+  $ cat >multierr.ny <<EOF
+  > axiom A:Type
+  > axiom a:A
+  > def foo : Type := sig (fst : a, snd : a)
+  > EOF
+
+  $ narya -v multierr.ny
+   ￫ info[I0001]
+   ￮ axiom A assumed
+  
+   ￫ info[I0001]
+   ￮ axiom a assumed
+  
+   ￫ error[E0401]
+   ￭ $TESTCASE_ROOT/multierr.ny
+   3 | def foo : Type := sig (fst : a, snd : a)
+     ^ term synthesized type A but is being checked against type Type
+  
+   ￫ error[E0401]
+   ￭ $TESTCASE_ROOT/multierr.ny
+   3 | def foo : Type := sig (fst : a, snd : a)
+     ^ term synthesized type A but is being checked against type Type
+  
+  [1]
+
+  $ cat >multierr.ny <<EOF
+  > axiom A:Type
+  > axiom a:A
+  > axiom B : A -> Type
+  > def foo : Type := sig (fst : a, snd : B fst)
+  > EOF
+
+  $ narya -v multierr.ny
+   ￫ info[I0001]
+   ￮ axiom A assumed
+  
+   ￫ info[I0001]
+   ￮ axiom a assumed
+  
+   ￫ info[I0001]
+   ￮ axiom B assumed
+  
+   ￫ error[E0401]
+   ￭ $TESTCASE_ROOT/multierr.ny
+   4 | def foo : Type := sig (fst : a, snd : B fst)
+     ^ term synthesized type A but is being checked against type Type
+  
+  [1]
+
+  $ cat >multierr.ny <<EOF
+  > axiom A:Type
+  > axiom a:A
+  > def foo : Type := codata [ x .fst : a | x .snd : a ]
+  > EOF
+
+  $ narya -v multierr.ny
+   ￫ info[I0001]
+   ￮ axiom A assumed
+  
+   ￫ info[I0001]
+   ￮ axiom a assumed
+  
+   ￫ error[E0401]
+   ￭ $TESTCASE_ROOT/multierr.ny
+   3 | def foo : Type := codata [ x .fst : a | x .snd : a ]
+     ^ term synthesized type A but is being checked against type Type
+  
+   ￫ error[E0401]
+   ￭ $TESTCASE_ROOT/multierr.ny
+   3 | def foo : Type := codata [ x .fst : a | x .snd : a ]
+     ^ term synthesized type A but is being checked against type Type
+  
+  [1]

--- a/test/black/multierror.t
+++ b/test/black/multierror.t
@@ -316,3 +316,28 @@ Even trivial dependency blocks going on, as long as there is the potential for d
      ^ term synthesized type A but is being checked against type B
   
   [1]
+
+  $ cat >multierr.ny <<EOF
+  > axiom A:Type
+  > axiom a:A
+  > def foo : Type := data [ true. (_ : a) | false. (_ : a) ]
+  > EOF
+
+  $ narya -v multierr.ny
+   ￫ info[I0001]
+   ￮ axiom A assumed
+  
+   ￫ info[I0001]
+   ￮ axiom a assumed
+  
+   ￫ error[E0401]
+   ￭ $TESTCASE_ROOT/multierr.ny
+   3 | def foo : Type := data [ true. (_ : a) | false. (_ : a) ]
+     ^ term synthesized type A but is being checked against type Type
+  
+   ￫ error[E0401]
+   ￭ $TESTCASE_ROOT/multierr.ny
+   3 | def foo : Type := data [ true. (_ : a) | false. (_ : a) ]
+     ^ term synthesized type A but is being checked against type Type
+  
+  [1]

--- a/test/black/multierror.t
+++ b/test/black/multierror.t
@@ -1,0 +1,285 @@
+  $ cat >multierr.ny <<EOF
+  > axiom A:Type
+  > axiom B:Type
+  > axiom C:Type
+  > axiom a:A
+  > def prod (X Y : Type) : Type := sig (fst:X, snd:Y)
+  > def foo : prod B C := (a,a)
+  > EOF
+
+  $ narya -v multierr.ny
+   ￫ info[I0001]
+   ￮ axiom A assumed
+  
+   ￫ info[I0001]
+   ￮ axiom B assumed
+  
+   ￫ info[I0001]
+   ￮ axiom C assumed
+  
+   ￫ info[I0001]
+   ￮ axiom a assumed
+  
+   ￫ info[I0000]
+   ￮ constant prod defined
+  
+   ￫ error[E0401]
+   ￭ $TESTCASE_ROOT/multierr.ny
+   6 | def foo : prod B C := (a,a)
+     ^ term synthesized type A but is being checked against type B
+  
+   ￫ error[E0401]
+   ￭ $TESTCASE_ROOT/multierr.ny
+   6 | def foo : prod B C := (a,a)
+     ^ term synthesized type A but is being checked against type C
+  
+  [1]
+
+  $ cat >multierr.ny <<EOF
+  > axiom A:Type
+  > axiom B:Type
+  > axiom C:Type
+  > axiom a:A
+  > axiom c:C
+  > def prod (X Y : Type) : Type := sig (fst:X, snd:Y)
+  > def foo : prod B C := (a,c)
+  > EOF
+
+  $ narya -v multierr.ny
+   ￫ info[I0001]
+   ￮ axiom A assumed
+  
+   ￫ info[I0001]
+   ￮ axiom B assumed
+  
+   ￫ info[I0001]
+   ￮ axiom C assumed
+  
+   ￫ info[I0001]
+   ￮ axiom a assumed
+  
+   ￫ info[I0001]
+   ￮ axiom c assumed
+  
+   ￫ info[I0000]
+   ￮ constant prod defined
+  
+   ￫ error[E0401]
+   ￭ $TESTCASE_ROOT/multierr.ny
+   7 | def foo : prod B C := (a,c)
+     ^ term synthesized type A but is being checked against type B
+  
+  [1]
+
+
+  $ cat >multierr.ny <<EOF
+  > axiom A:Type
+  > axiom B:Type
+  > axiom C:Type
+  > axiom a:A
+  > def prod (X Y : Type) : Type := sig (fst:X, snd:Y)
+  > def foo : prod (prod B C) (prod C B) := ((a,a),(a,a))
+  > EOF
+
+  $ narya -v multierr.ny
+   ￫ info[I0001]
+   ￮ axiom A assumed
+  
+   ￫ info[I0001]
+   ￮ axiom B assumed
+  
+   ￫ info[I0001]
+   ￮ axiom C assumed
+  
+   ￫ info[I0001]
+   ￮ axiom a assumed
+  
+   ￫ info[I0000]
+   ￮ constant prod defined
+  
+   ￫ error[E0401]
+   ￭ $TESTCASE_ROOT/multierr.ny
+   6 | def foo : prod (prod B C) (prod C B) := ((a,a),(a,a))
+     ^ term synthesized type A but is being checked against type B
+  
+   ￫ error[E0401]
+   ￭ $TESTCASE_ROOT/multierr.ny
+   6 | def foo : prod (prod B C) (prod C B) := ((a,a),(a,a))
+     ^ term synthesized type A but is being checked against type C
+  
+   ￫ error[E0401]
+   ￭ $TESTCASE_ROOT/multierr.ny
+   6 | def foo : prod (prod B C) (prod C B) := ((a,a),(a,a))
+     ^ term synthesized type A but is being checked against type C
+  
+   ￫ error[E0401]
+   ￭ $TESTCASE_ROOT/multierr.ny
+   6 | def foo : prod (prod B C) (prod C B) := ((a,a),(a,a))
+     ^ term synthesized type A but is being checked against type B
+  
+  [1]
+
+  $ cat >multierr.ny <<EOF
+  > axiom A:Type
+  > axiom B:Type
+  > axiom P:B->Type
+  > axiom a:A
+  > def Sigma (X : Type) (Y : X -> Type) : Type := sig (fst:X, snd:Y fst)
+  > def foo : Sigma B P := (a,a)
+  > EOF
+
+  $ narya -v multierr.ny
+   ￫ info[I0001]
+   ￮ axiom A assumed
+  
+   ￫ info[I0001]
+   ￮ axiom B assumed
+  
+   ￫ info[I0001]
+   ￮ axiom P assumed
+  
+   ￫ info[I0001]
+   ￮ axiom a assumed
+  
+   ￫ info[I0000]
+   ￮ constant Sigma defined
+  
+   ￫ error[E0401]
+   ￭ $TESTCASE_ROOT/multierr.ny
+   6 | def foo : Sigma B P := (a,a)
+     ^ term synthesized type A but is being checked against type B
+  
+  [1]
+
+  $ cat >multierr.ny <<EOF
+  > axiom A:Type
+  > axiom B:Type
+  > axiom a:A
+  > def bool : Type := data [ true. | false. ]
+  > def P : bool -> Type := [ true. |-> A | false. |-> B ]
+  > def Sigma (X : Type) (Y : X -> Type) : Type := sig (fst:X, snd:Y fst)
+  > def foo : Sigma bool P := (a, a)
+  > EOF
+
+  $ narya -v multierr.ny
+   ￫ info[I0001]
+   ￮ axiom A assumed
+  
+   ￫ info[I0001]
+   ￮ axiom B assumed
+  
+   ￫ info[I0001]
+   ￮ axiom a assumed
+  
+   ￫ info[I0000]
+   ￮ constant bool defined
+  
+   ￫ info[I0000]
+   ￮ constant P defined
+  
+   ￫ info[I0000]
+   ￮ constant Sigma defined
+  
+   ￫ error[E0401]
+   ￭ $TESTCASE_ROOT/multierr.ny
+   7 | def foo : Sigma bool P := (a, a)
+     ^ term synthesized type A but is being checked against type bool
+  
+  [1]
+
+Even trivial dependency blocks going on, as long as there is the potential for dependency.  Avoiding this would probably involve more laziness in function arguments.
+
+  $ cat >multierr.ny <<EOF
+  > axiom A:Type
+  > axiom B:Type
+  > axiom a:A
+  > def Sigma (X : Type) (Y : X -> Type) : Type := sig (fst:X, snd:Y fst)
+  > def foo : Sigma B (_ ↦ B) := (a, a)
+  > EOF
+
+  $ narya -v multierr.ny
+   ￫ info[I0001]
+   ￮ axiom A assumed
+  
+   ￫ info[I0001]
+   ￮ axiom B assumed
+  
+   ￫ info[I0001]
+   ￮ axiom a assumed
+  
+   ￫ info[I0000]
+   ￮ constant Sigma defined
+  
+   ￫ error[E0401]
+   ￭ $TESTCASE_ROOT/multierr.ny
+   5 | def foo : Sigma B (_ ↦ B) := (a, a)
+     ^ term synthesized type A but is being checked against type B
+  
+  [1]
+
+
+  $ cat >multierr.ny <<EOF
+  > axiom A:Type
+  > axiom B:Type
+  > axiom a:A
+  > def streamB : Type := codata [ x .head : B | x .tail : streamB ]
+  > def foo : streamB := [ .head ↦ a | .tail ↦ a ]
+  > EOF
+
+  $ narya -v multierr.ny
+   ￫ info[I0001]
+   ￮ axiom A assumed
+  
+   ￫ info[I0001]
+   ￮ axiom B assumed
+  
+   ￫ info[I0001]
+   ￮ axiom a assumed
+  
+   ￫ info[I0000]
+   ￮ constant streamB defined
+  
+   ￫ error[E0401]
+   ￭ $TESTCASE_ROOT/multierr.ny
+   5 | def foo : streamB := [ .head ↦ a | .tail ↦ a ]
+     ^ term synthesized type A but is being checked against type B
+  
+   ￫ error[E0401]
+   ￭ $TESTCASE_ROOT/multierr.ny
+   5 | def foo : streamB := [ .head ↦ a | .tail ↦ a ]
+     ^ term synthesized type A but is being checked against type streamB
+  
+  [1]
+
+  $ cat >multierr.ny <<EOF
+  > axiom A:Type
+  > axiom B:Type
+  > axiom a:A
+  > def streamB : Type := codata [ x .head : B | x .tail : streamB ]
+  > def foo : B := let x : streamB := [ .head ↦ a | .tail ↦ a ] in x .head
+  > EOF
+
+  $ narya -v multierr.ny
+   ￫ info[I0001]
+   ￮ axiom A assumed
+  
+   ￫ info[I0001]
+   ￮ axiom B assumed
+  
+   ￫ info[I0001]
+   ￮ axiom a assumed
+  
+   ￫ info[I0000]
+   ￮ constant streamB defined
+  
+   ￫ error[E0401]
+   ￭ $TESTCASE_ROOT/multierr.ny
+   5 | def foo : B := let x : streamB := [ .head ↦ a | .tail ↦ a ] in x .head
+     ^ term synthesized type A but is being checked against type B
+  
+   ￫ error[E0401]
+   ￭ $TESTCASE_ROOT/multierr.ny
+   5 | def foo : B := let x : streamB := [ .head ↦ a | .tail ↦ a ] in x .head
+     ^ term synthesized type A but is being checked against type streamB
+  
+  [1]

--- a/test/black/multierror.t
+++ b/test/black/multierror.t
@@ -283,3 +283,36 @@ Even trivial dependency blocks going on, as long as there is the potential for d
      ^ term synthesized type A but is being checked against type streamB
   
   [1]
+
+  $ cat >multierr.ny <<EOF
+  > axiom A:Type
+  > axiom B:Type
+  > axiom a:A
+  > def bool : Type := data [ true. | false. ]
+  > def foo (x : bool) : B := match x [ true. ↦ a | false. ↦ a ]
+  > EOF
+
+  $ narya -v multierr.ny
+   ￫ info[I0001]
+   ￮ axiom A assumed
+  
+   ￫ info[I0001]
+   ￮ axiom B assumed
+  
+   ￫ info[I0001]
+   ￮ axiom a assumed
+  
+   ￫ info[I0000]
+   ￮ constant bool defined
+  
+   ￫ error[E0401]
+   ￭ $TESTCASE_ROOT/multierr.ny
+   5 | def foo (x : bool) : B := match x [ true. ↦ a | false. ↦ a ]
+     ^ term synthesized type A but is being checked against type B
+  
+   ￫ error[E0401]
+   ￭ $TESTCASE_ROOT/multierr.ny
+   5 | def foo (x : bool) : B := match x [ true. ↦ a | false. ↦ a ]
+     ^ term synthesized type A but is being checked against type B
+  
+  [1]

--- a/test/black/multierror.t
+++ b/test/black/multierror.t
@@ -415,3 +415,23 @@ Even trivial dependency blocks going on, as long as there is the potential for d
      ^ term synthesized type A but is being checked against type Type
   
   [1]
+
+  $ cat >multierr.ny <<EOF
+  > def Nat : Type := data [ zero. | suc. (_ : Nat) ]
+  > axiom f : Nat -> Nat
+  > def pred (x : Nat) : Nat := match x [ zero. |-> Nat | suc. y |-> f (pred y) ]
+  > EOF
+
+  $ narya -v multierr.ny
+   ￫ info[I0000]
+   ￮ constant Nat defined
+  
+   ￫ info[I0001]
+   ￮ axiom f assumed
+  
+   ￫ error[E0401]
+   ￭ $TESTCASE_ROOT/multierr.ny
+   3 | def pred (x : Nat) : Nat := match x [ zero. |-> Nat | suc. y |-> f (pred y) ]
+     ^ term synthesized type Type but is being checked against type Nat
+  
+  [1]

--- a/test/parser/ambiguity.ml
+++ b/test/parser/ambiguity.ml
@@ -4,7 +4,6 @@ open Parser
 open Notation
 open Testutil
 open Showparse
-module Terminal = Asai.Tty.Make (Core.Reporter.Code)
 
 (* We raise an error if one notation is a prefix of another, since parsing such combinations would require too much backtracking.  Here we test the generation of that error. *)
 
@@ -23,8 +22,8 @@ let () =
           (term (Ident [ "then" ]) (term (Ident [ "else" ]) (Done_closed ifthenelse)))))
 
 let () =
-  Reporter.run ~emit:Terminal.display ~fatal:(fun d ->
-      Terminal.display d;
+  Reporter.run ~emit:Reporter.display ~fatal:(fun d ->
+      Reporter.display d;
       raise (Failure "Parse failure"))
   @@ fun () ->
   Situation.run_on Situation.empty @@ fun () ->
@@ -32,8 +31,8 @@ let () =
   assert (parse "if x then y" = Notn ("ifthen", [ Term (Ident [ "x" ]); Term (Ident [ "y" ]) ]))
 
 let () =
-  Reporter.run ~emit:Terminal.display ~fatal:(fun d ->
-      Terminal.display d;
+  Reporter.run ~emit:Reporter.display ~fatal:(fun d ->
+      Reporter.display d;
       raise (Failure "Parse failure"))
   @@ fun () ->
   Situation.run_on Situation.empty @@ fun () ->
@@ -43,13 +42,13 @@ let () =
     = Notn ("ifthenelse", [ Term (Ident [ "x" ]); Term (Ident [ "y" ]); Term (Ident [ "z" ]) ]))
 
 let () =
-  Reporter.run ~emit:Terminal.display ~fatal:(fun d ->
+  Reporter.run ~emit:Reporter.display ~fatal:(fun d ->
       if
         d.message
         = Parsing_ambiguity "One notation is a prefix of another: [ifthen] and [ifthenelse]"
       then ()
       else (
-        Terminal.display d;
+        Reporter.display d;
         raise (Failure "Unexpected error code")))
   @@ fun () ->
   Situation.run_on Situation.empty @@ fun () ->
@@ -68,8 +67,8 @@ let () =
           (term (Ident [ "then" ]) (term (Ident [ "elif" ]) (Done_closed ifthenelif)))))
 
 let () =
-  Reporter.run ~emit:Terminal.display ~fatal:(fun d ->
-      Terminal.display d;
+  Reporter.run ~emit:Reporter.display ~fatal:(fun d ->
+      Reporter.display d;
       raise (Failure "Parse failure"))
   @@ fun () ->
   Situation.run_on Situation.empty @@ fun () ->

--- a/test/testutil/pmp.ml
+++ b/test/testutil/pmp.ml
@@ -89,8 +89,6 @@ let ( $. ) x fld = Field (x, fld)
 let struc tms = Struct tms
 let ( $^ ) x s = Deg (x, s)
 
-module Terminal = Asai.Tty.Make (Core.Reporter.Code)
-
 (* The current context of assumptions, including names. *)
 type ctx = Ctx : ('n, 'b) Ctx.t * (string, 'n) Bwv.t -> ctx
 
@@ -101,8 +99,8 @@ let context = ref ectx
 
 let synth (tm : pmt) : kinetic value * kinetic value =
   let (Ctx (ctx, names)) = !context in
-  Reporter.run ~emit:Terminal.display ~fatal:(fun d ->
-      Terminal.display d;
+  Reporter.run ~emit:Reporter.display ~fatal:(fun d ->
+      Reporter.display d;
       raise (Failure "Failed to synthesize"))
   @@ fun () ->
   let raw = parse_syn names tm in
@@ -112,8 +110,8 @@ let synth (tm : pmt) : kinetic value * kinetic value =
 
 let check (tm : pmt) (ty : kinetic value) : kinetic value =
   let (Ctx (ctx, names)) = !context in
-  Reporter.run ~emit:Terminal.display ~fatal:(fun d ->
-      Terminal.display d;
+  Reporter.run ~emit:Reporter.display ~fatal:(fun d ->
+      Reporter.display d;
       raise (Failure "Failed to check"))
   @@ fun () ->
   let raw = parse_chk names tm in
@@ -124,14 +122,14 @@ let check (tm : pmt) (ty : kinetic value) : kinetic value =
 
 let unsynth (tm : pmt) : unit =
   let (Ctx (ctx, names)) = !context in
-  Reporter.run ~emit:Terminal.display ~fatal:(fun _ -> ()) @@ fun () ->
+  Reporter.run ~emit:Reporter.display ~fatal:(fun _ -> ()) @@ fun () ->
   let raw = parse_syn names tm in
   let _ = Check.synth (Kinetic `Nolet) ctx raw in
   raise (Failure "Synthesis success")
 
 let uncheck (tm : pmt) (ty : kinetic value) : unit =
   let (Ctx (ctx, names)) = !context in
-  Reporter.run ~emit:Terminal.display ~fatal:(fun _ -> ()) @@ fun () ->
+  Reporter.run ~emit:Reporter.display ~fatal:(fun _ -> ()) @@ fun () ->
   let raw = parse_chk names tm in
   let _ = Check.check (Kinetic `Nolet) ctx raw ty in
   raise (Failure "Checking success")

--- a/test/testutil/print.ml
+++ b/test/testutil/print.ml
@@ -17,11 +17,9 @@ let reformat content =
   pp_print_newline std_formatter ();
   pp_print_newline std_formatter ()
 
-module Terminal = Asai.Tty.Make (Core.Reporter.Code)
-
 let run f =
-  Reporter.run ~emit:Terminal.display ~fatal:(fun d ->
-      Terminal.display d;
+  Reporter.run ~emit:Reporter.display ~fatal:(fun d ->
+      Reporter.display d;
       raise (Failure "Fatal error"))
   @@ fun () ->
   Builtins.run @@ fun () ->

--- a/test/testutil/repl.ml
+++ b/test/testutil/repl.ml
@@ -22,8 +22,6 @@ let parse_term (tm : string) : N.zero check located =
   let (Term tm) = Parse.Term.final p in
   Postprocess.process Emp tm
 
-module Terminal = Asai.Tty.Make (Core.Reporter.Code)
-
 let check_type (rty : N.zero check located) : (emp, kinetic) term =
   Reporter.trace "when checking type" @@ fun () ->
   check (Kinetic `Nolet) Ctx.empty rty (universe D.zero)
@@ -119,8 +117,10 @@ let run f =
   Readback.Display.run ~env:false @@ fun () ->
   Discrete.run ~env:false @@ fun () ->
   Compunit.Current.run ~env:Compunit.basic @@ fun () ->
-  Reporter.run ~emit:Terminal.display ~fatal:(fun d ->
-      Terminal.display d;
+  Reporter.run
+    ~emit:(fun d -> Reporter.display d)
+    ~fatal:(fun d ->
+      Reporter.display d;
       raise (Failure "Fatal error"))
   @@ fun () ->
   let init_visible = Parser.Pi.install Scope.Trie.empty in


### PR DESCRIPTION
With this change, when one "branch" of a definition (e.g. component of a tuple, branch of a match or comatch, field of a record or codata type, or constructor of a datatype) fails to typecheck, instead of bailing out immediately with the error, we save it and continue typechecking the other branches.  Any other branches that depend on a previous branch are ignored, as are those that typecheck correctly, but any errors produced by other branches that don't depend on a previous branch are accumulated and reported all together at the end.  This way, for instance, if you're defining an ordered pair, you don't have to fix the first component before learning that there's also an error in the second component.  For example:

```
axiom a : A
axiom b : B
def p : A × B ≔ (b, a)

 ￫ error[E0401]
 ￭ interactive input
 1 | def p : A × B ≔ (b, a)
   ^ term synthesized type B but is being checked against type A

 ￫ error[E0401]
 ￭ interactive input
 1 | def p : A × B ≔ (b, a)
   ^ term synthesized type A but is being checked against type B
```
(where `b` is underlined in the first error message and `a` in the second).

Current limitations include:
1. Parse errors and scoping errors can't be accumulated, as parsing and scope-checking happens at an earlier stage than typechecking.
2. Only branches that are syntactically evidently non-dependent on previous ones can have errors accumulated.  In particular, a non-dependent sigma-type like `Σ A (_ ↦ B)` can't be used in the above example; even though the second component doesn't actually depend on the first, syntactically it might.  This might be improvable with more laziness.
3. After one error is encountered, we skip all later branches that depend at all on *any* earlier branches, even if they only depend on branches whose typechecking succeeded.  This includes all branches that make recursive calls (unless a different error occurs before encountering the recursive call during typechecking).  Improving this would require a very different way of "dependency checking"; currently we just bind the variable/constant being defined to a flag that produces an error if it is ever used.