### PR TITLE
proof-general narya-solve-hole function

### DIFF
--- a/bin/narya.ml
+++ b/bin/narya.ml
@@ -147,7 +147,7 @@ let rec interact_pg () : unit =
     done;
     let cmd = Buffer.contents buf in
     let holes = ref Emp in
-    ( Global.HolePos.run ~init:Emp @@ fun () ->
+    ( Global.HolePos.run ~init:{ holes = Emp; offset = 0 } @@ fun () ->
       Reporter.try_with
       (* ProofGeneral sets TERM=dumb, but in fact it can display ANSI colors, so we tell Asai to override TERM and use colors unconditionally. *)
         ~emit:(fun d ->
@@ -165,9 +165,10 @@ let rec interact_pg () : unit =
                 Format.printf "\n\n%!")
               [ !holes ];
             Format.printf "\x0C[data]\x0C\n%!";
+            let st = Global.HolePos.get () in
             Mbwd.miter
-              (fun [ (h, s, e) ] -> Format.printf "%d %d %d\n" h s e)
-              [ Global.HolePos.get () ]
+              (fun [ (h, s, e) ] -> Format.printf "%d %d %d\n" h (s - st.offset) (e - st.offset))
+              [ st.holes ]
           with Sys.Break -> Reporter.fatal Break) );
     interact_pg ()
   with End_of_file -> ()

--- a/lib/core/global.ml
+++ b/lib/core/global.ml
@@ -229,10 +229,14 @@ let get () =
 let run = S.run
 let try_with = S.try_with
 
-module HolePos = State.Make (struct
-  type t = (int * int * int) Bwd.t
-end)
+(* Store the hole number, starting position, and ending position of each newly created hole, to report to ProofGeneral. *)
+module HoleState = struct
+  type t = { holes : (int * int * int) Bwd.t; offset : int }
+end
 
+module HolePos = State.Make (HoleState)
+
+(* Notify the user about currently created holes and add them to the global list. *)
 let do_holes make_msg =
   let d = S.get () in
   emit (make_msg (Bwd.length d.current_holes));
@@ -240,7 +244,8 @@ let do_holes make_msg =
     (fun [ (Meta.Wrap m, p, (pos : unit Asai.Range.located)) ] ->
       emit (Hole (Meta.name m, p));
       let s, e = Asai.Range.split (Option.get pos.loc) in
-      HolePos.modify (fun holes -> Snoc (holes, (Meta.hole_number m, s.offset, e.offset))))
+      HolePos.modify (fun st ->
+          { st with holes = Snoc (st.holes, (Meta.hole_number m, s.offset, e.offset)) }))
     [ d.current_holes ];
   d.current_metas
 

--- a/lib/core/global.mli
+++ b/lib/core/global.mli
@@ -61,9 +61,11 @@ type eternity = {
 
 val eternity : eternity ref
 
-module HolePos : module type of State.Make (struct
-  type t = (int * int * int) Bwd.t
-end)
+module HoleState : sig
+  type t = { holes : (int * int * int) Bwd.t; offset : int }
+end
+
+module HolePos : module type of State.Make (HoleState)
 
 val end_command : (int -> Reporter.Code.t) -> unit
 val run_command_with : init:data -> (int -> Reporter.Code.t) -> (unit -> 'a) -> 'a

--- a/lib/top/top.ml
+++ b/lib/top/top.ml
@@ -77,7 +77,8 @@ let run_top ?use_ansi ?(exiter = fun () -> exit 1) f =
   History.run_empty @@ fun () ->
   Eternity.run ~init:Eternity.empty @@ fun () ->
   (* By default, we ignore the hole positions. *)
-  Global.HolePos.try_with ~get:(fun () -> Emp) ~set:(fun _ -> ()) @@ fun () ->
+  Global.HolePos.try_with ~get:(fun () -> { holes = Emp; offset = 0 }) ~set:(fun _ -> ())
+  @@ fun () ->
   Printconfig.run
     ~env:
       {


### PR DESCRIPTION
I used the changes in `hole-offsets` branch, edited the `narya-handle-output` and wrote `narya-solve-hole` function. I did not observe any error we received before, so I think it's better now.

What I've done : 

- add `narya-pending-hole-positions` in order to store temporarily the hole positions when executing commands invisibly.

- edited `narya-handle-output` so that if called with an invisible command, store hole data in pending position instead of creating overlays immediately.

- created `narya-solve-hole` with the following properties:
  
  - When a hole created after a load (C-c C-n), use C-c C-SPC to enter the process
  - If the cursor is on a hole "`?`", then you will be asked to enter a `term`
  - If the term succeeds, namely; no error in `solve %d := term` command, then the hole will be replaced with `(term)`. Putting parentheses is to avoid possible parsing problem. If we find a better way, we can edit this in the future.
  - Since the solve command is invisible during the process, we stored the data in pending hole positions. So in the case `term` includes new holes, we should store them in `narya-hole` again. 
  - After processing all pending holes, `narya-pending-hole-positions` is cleared, ensuring no redundant data remains.

Let me know if you think it needs correction or more improvement.

