### PR TITLE
adding delete overlay function after exit

### DIFF
--- a/proofgeneral/narya.el
+++ b/proofgeneral/narya.el
@@ -18,6 +18,13 @@
 
 (defvar narya-hole-overlays nil
   "List of overlays marking the locations of open holes")
+  
+(defun narya-delete-all-holes ()
+  "Delete all hole overlays and reset `narya-hole-overlays' to nil."
+  (mapc #'delete-overlay narya-hole-overlays)
+  (setq narya-hole-overlays nil))
+
+(add-hook 'proof-shell-kill-function-hooks #'narya-delete-all-holes)
 
 (defface narya-hole-face '((t . (:background "SlateGray4" :foreground "white" :weight bold)))
   "Face used for open holes in Narya")


### PR DESCRIPTION
Regarding [the issue](https://github.com/mikeshulman/narya/issues/37), I've checked which command is runned by C-c C-x, and received the following output. Then I checked PG repo, it seems `proof-shell-kill-function-hooks` is the right hook. The edited .el file worked as we expected.

```emacs
C-c C-x runs the command proof-shell-exit (found in narya-mode-map),
which is an interactive native-comp-function in ‘proof-shell.el’.

It is bound to C-c C-x.

(proof-shell-exit &optional DONT-ASK)

Query the user and exit the proof process.

This simply kills the ‘proof-shell-buffer’ relying on the hook function

‘proof-shell-kill-function’ to do the hard work.  If optional
argument DONT-ASK is non-nil, the proof process is terminated
without confirmation.

The kill function uses ‘<PA>-quit-timeout’ as a timeout to wait
after sending ‘proof-shell-quit-cmd’ before rudely killing the process.

This function should not be called if
‘proof-shell-exit-in-progress’ is t, because a recursive call of
‘proof-shell-kill-function’ will give strange errors.
```
